### PR TITLE
IDiaryEntry.previous が undefined を受け取らないようにする。

### DIFF
--- a/game-diary/src/app/model/diary/diaryEntry.ts
+++ b/game-diary/src/app/model/diary/diaryEntry.ts
@@ -42,7 +42,7 @@ export class DiaryEntry implements IDiaryEntry {
   get next(): number | undefined {
     return this._next;
   }
-  set previous(val: number | undefined) {
+  set previous(val: number) {
     if (
       (this.day === 1 && val === undefined) || // 初日だけundefinedを許す
       (val !== undefined && this.day > val && val > 0) // 前日は今日より大きくないし1未満にならない

--- a/game-diary/src/app/model/diary/diaryModelInterfaces.ts
+++ b/game-diary/src/app/model/diary/diaryModelInterfaces.ts
@@ -40,7 +40,7 @@ export interface IDiaryEntry {
   setContent(val: string): void;
   getContent(): string;
   /** 前日のエントリーの日付 */
-  set previous(val: number | undefined); //TODO:前日がundefinedになるのは初日だけなのでundefinedを受け付けない。
+  set previous(val: number);
   get previous(): number | undefined;
   /** 翌日のエントリーの日付 */
   set next(val: number | undefined);


### PR DESCRIPTION
Fixes #18