### PR TITLE
DiaryEntryFactory.createUsePreviousDay で生成されるインスタンスの day が前日のものになっている問題の修正

### DIFF
--- a/game-diary/src/lib/model/diary/diaryEntryFactory.ts
+++ b/game-diary/src/lib/model/diary/diaryEntryFactory.ts
@@ -12,7 +12,7 @@ export default class DiaryEntryFactory implements IDiaryEntryFactory {
   ): IDiaryEntry {
     const today = settings.getNextDay(source.day);
     const title = settings.getModifierDay(today);
-    const entry = new DiaryEntry(source.day, title, '', source.day, undefined);
+    const entry = new DiaryEntry(today, title, '', source.day, undefined);
     return entry;
   }
 


### PR DESCRIPTION
Fixes #157