### PR TITLE
feat: セーブ機能の改善とリファクタリング

### DIFF
--- a/game-diary/src/app/page.tsx
+++ b/game-diary/src/app/page.tsx
@@ -7,21 +7,33 @@ import Settings from 'src/components/settings/settings';
 import Header from 'src/components/mainContent/header';
 import DiaryEntryContent from 'src/components/mainContent/diaryEntryContent';
 import Background from 'src/components/background';
+import { useEffect } from 'react';
+import executeSave from 'src/hooks/executeSave';
 const DiaryLayout = () => {
+  useEffect(() => {
+    const onSaveShortcut = (e: KeyboardEvent) => {
+      if (e.key === 's' && e.ctrlKey) {
+        e.preventDefault();
+        executeSave();
+      }
+    };
+    window.addEventListener('keydown', onSaveShortcut);
+    return () => window.removeEventListener('keydown', onSaveShortcut);
+  }, []);
   return (
     <ContextProvider>
       <Toaster position="bottom-center" reverseOrder={false} />
       <Background>
         {/* 左サイドバー */}
-        <Sidebar></Sidebar>
+        <Sidebar />
         {/* メインエリア */}
         <div className="flex-1 flex flex-col">
           {/* ヘッダー */}
-          <Header></Header>
+          <Header />
           {/* コンテンツエリア */}
-          <DiaryEntryContent></DiaryEntryContent>
+          <DiaryEntryContent />
           {/* 設定エリア */}
-          <Settings></Settings>
+          <Settings />
         </div>
       </Background>
     </ContextProvider>

--- a/game-diary/src/components/sidebar/sidebar.tsx
+++ b/game-diary/src/components/sidebar/sidebar.tsx
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import { darkButton, lightButton } from '../component_styles';
 import DiaryEntriesList from './diaryEntriesList';
-import handleSave from 'src/hooks/handleSave';
+import executeSave from 'src/hooks/executeSave';
 import ExportModal from '../modals/exportModal';
 import ImportModal from '../modals/importModal';
 import LoadModal from '../modals/loadModal';
@@ -32,7 +32,7 @@ const Sidebar = () => {
       <div className={`grid grid-cols-2 gap-2`}>
         <button
           className={`overflow-hidden ${isDarkMode ? darkButton : lightButton}`}
-          onClick={() => handleSave()}
+          onClick={executeSave}
         >
           セーブ
         </button>

--- a/game-diary/src/hooks/executeSave.ts
+++ b/game-diary/src/hooks/executeSave.ts
@@ -2,7 +2,7 @@ import { IDiarySaveHandler } from '@/control/controlDiary/controlDiaryInterface'
 import toast from 'react-hot-toast';
 import { container } from 'tsyringe';
 
-const handleSave = async () => {
+const executeSave = async () => {
   try {
     container.resolve<IDiarySaveHandler>('IDiarySaveHandler').save();
     toast.success('セーブしました');
@@ -11,4 +11,4 @@ const handleSave = async () => {
     throw err;
   }
 };
-export default handleSave;
+export default executeSave;

--- a/game-diary/src/lib/container/di_diary.ts
+++ b/game-diary/src/lib/container/di_diary.ts
@@ -81,6 +81,14 @@ import {
 import CurrentDiaryEntryAccessor from '@/control/controlDiaryEntry/currentDiaryEntryAccessor';
 import DeleteDiaryEntry from '@/control/controlDiaryEntry/deleteDiaryEntry';
 import EditDiaryEntry from '@/control/controlDiaryEntry/editDiaryEntry';
+import {
+  CompressDiary,
+  IDiaryDecompressor,
+} from '@/model/serialization/serializationInterface';
+import {
+  compressDiary,
+  DiaryDecompressor,
+} from '@/model/serialization/diarySerializer';
 
 // diaryModelInterfaces
 container.register<UsePreviousDayDiaryEntryFactory>(
@@ -197,14 +205,16 @@ container.register<UseExistingDataDayModifierFactory>(
         new DayModifier(modifier, cycleLength, ...unit),
   }
 );
+
 // storageServiceInterfaces
 container.registerSingleton<IStorageService>(
   'IStorageService',
   LocalStorageService
 );
 container.register<IsStorageAvailableFunc>('IsStorageAvailableFunc', {
-  useFactory: () => isStorageAvailable,
+  useValue: isStorageAvailable,
 });
+
 // diaryRepositoryInterfaces
 container.registerSingleton<IDiaryService>('IDiaryService', DiaryService);
 container.registerSingleton<IDiaryNameManager>(
@@ -227,6 +237,7 @@ container.registerSingleton<IDiaryImport>('IDiaryImport', DiaryImport);
 container.registerSingleton<IDiaryExport>('IDiaryExport', DiaryExport);
 container.registerSingleton<IDiarySave>('IDiarySave', DiarySave);
 container.registerSingleton<IDiaryLoad>('IDiaryLoad', DiaryLoad);
+
 // controlDiaryInterfaces
 container.registerSingleton<ICurrentDiaryAccessor>(
   'ICurrentDiaryAccessor',
@@ -263,3 +274,9 @@ container.registerSingleton<IEditDiarySettings>(
   EditDiarySettings
 );
 container.registerSingleton<IEditDiaryEntry>('IEditDiaryEntry', EditDiaryEntry);
+
+// serializationInterface
+container.register<CompressDiary>('CompressDiary', { useValue: compressDiary });
+container.register<IDiaryDecompressor>('IDiaryDecompressor', {
+  useClass: DiaryDecompressor,
+});

--- a/game-diary/src/lib/control/controlDiary/diarySaveHandler.ts
+++ b/game-diary/src/lib/control/controlDiary/diarySaveHandler.ts
@@ -1,14 +1,15 @@
-import { inject } from 'tsyringe';
+import { inject, injectable } from 'tsyringe';
 import type {
   ICurrentDiaryAccessor,
   IDiarySaveHandler,
 } from './controlDiaryInterface';
 import type { IDiarySave } from '@/model/repository/diaryRepositoryInterfaces';
-
+@injectable()
 export default class DiarySaveHandler implements IDiarySaveHandler {
   constructor(
     @inject('IDiarySave') private diarySave: IDiarySave,
-    @inject('IDiarySave') private diaryAccessor: ICurrentDiaryAccessor
+    @inject('ICurrentDiaryAccessor')
+    private diaryAccessor: ICurrentDiaryAccessor
   ) {}
   save(): void {
     const diary = this.diaryAccessor.getCurrentDiary();


### PR DESCRIPTION
- executeSaveフックを新規作成し、セーブ処理を統一
- DiaryLayoutコンポーネントでCtrl+Sショートカットを追加
- Sidebarコンポーネントでセーブボタンの処理をexecuteSaveに変更
- 不要なhandleSaveフックを削除
- DiarySaveHandlerクラスの依存関係を修正
- di_diary.tsで新しいシリアライズ機能を登録