### PR TITLE
feat: 日記削除機能の実装と日記名管理のリファクタリング

### DIFF
--- a/game-diary/src/components/context/changeCurrentEntryContext.tsx
+++ b/game-diary/src/components/context/changeCurrentEntryContext.tsx
@@ -19,7 +19,7 @@ export const ChangeCurrentEntryProvider = ({
     useState<IChangeCurrentDiaryEntry | null>(null);
   const [entryAccessor, setEntryAccessor] =
     useState<ICurrentDiaryEntryAccessor | null>(null);
-  const { refresh } = useDiaryEntryResetContext();
+  const { refreshEntry } = useDiaryEntryResetContext();
   const { addDiaryEntry, detachDiaryEntry } = useDiaryEntriesListContext();
   // コンポーネントがマウントされたときにIChangeCurrentDiaryEntryのインスタンスを取得
   useEffect(() => {
@@ -39,7 +39,7 @@ export const ChangeCurrentEntryProvider = ({
     const onArrow = (e: KeyboardEvent) => {
       if (e.key === 'ArrowRight' && e.ctrlKey) {
         const isCreated = changeCurrentEntry.moveToNext();
-        refresh();
+        refreshEntry();
         if (!isCreated) {
           return;
         }
@@ -50,7 +50,7 @@ export const ChangeCurrentEntryProvider = ({
       if (e.key === 'ArrowLeft' && e.ctrlKey) {
         const day = entryAccessor.getCurrentDiaryEntry().day;
         const isDeleted = changeCurrentEntry.moveToPrevious();
-        refresh();
+        refreshEntry();
         if (!isDeleted) {
           return;
         }
@@ -69,7 +69,7 @@ export const ChangeCurrentEntryProvider = ({
       return;
     }
     changeCurrentEntry.moveByDate(date);
-    refresh();
+    refreshEntry();
   };
   return (
     <ChangeCurrentEntryContext.Provider value={{ moveByDate }}>

--- a/game-diary/src/components/context/contexts.tsx
+++ b/game-diary/src/components/context/contexts.tsx
@@ -4,15 +4,20 @@ import { DiaryEntriesListProvider } from './diaryEntryListContext';
 import { DiaryNameListProvider } from './diaryNameListContext';
 import { DiaryEntryProvider } from './diaryEntryContext';
 import ContextWrapperProps from './contextWrapperProps';
+import { SelectedDiaryProvider } from './selectedDiaryContext';
 const ContextProvider = ({ children }: ContextWrapperProps) => {
   return (
     <DarkMeadContextProvider>
       <DiaryNameListProvider>
-        <DiaryEntriesListProvider>
-          <DiaryEntryProvider>
-            <ChangeCurrentEntryProvider>{children}</ChangeCurrentEntryProvider>
-          </DiaryEntryProvider>
-        </DiaryEntriesListProvider>
+        <SelectedDiaryProvider>
+          <DiaryEntriesListProvider>
+            <DiaryEntryProvider>
+              <ChangeCurrentEntryProvider>
+                {children}
+              </ChangeCurrentEntryProvider>
+            </DiaryEntryProvider>
+          </DiaryEntriesListProvider>
+        </SelectedDiaryProvider>
       </DiaryNameListProvider>
     </DarkMeadContextProvider>
   );

--- a/game-diary/src/components/context/diaryEntryContext.tsx
+++ b/game-diary/src/components/context/diaryEntryContext.tsx
@@ -23,8 +23,8 @@ type DiaryEntryContentContextType = {
 const DiaryEntryContentContext =
   createContext<DiaryEntryContentContextType | null>(null);
 type DiaryEntryResetContextType = {
-  refresh: () => void;
-  clear: () => void;
+  refreshEntry: () => void;
+  clearEntry: () => void;
 };
 const DiaryEntryResetContext = createContext<DiaryEntryResetContextType | null>(
   null
@@ -63,25 +63,25 @@ export const DiaryEntryProvider = ({ children }: ContextWrapperProps) => {
     return null;
   }
   const titleObj: DiaryEntryTitleContextType = {
-    title: title,
+    title,
     updateTitle: (title) => {
       updateTitle(title);
       const day = currentDiaryEntry.getCurrentDiaryEntry().day;
       updateDiaryEntryTitle(day, title);
     },
-    refreshTitle: refreshTitle,
+    refreshTitle,
   };
   const contentObj: DiaryEntryContentContextType = {
     content: content,
-    updateContent: updateContent,
-    refreshContent: refreshContent,
+    updateContent,
+    refreshContent,
   };
   const resetObj: DiaryEntryResetContextType = {
-    refresh: () => {
+    refreshEntry: () => {
       refreshTitle();
       refreshContent();
     },
-    clear: () => {
+    clearEntry: () => {
       clear();
       refreshTitle();
       refreshContent();

--- a/game-diary/src/components/context/selectedDiaryContext.tsx
+++ b/game-diary/src/components/context/selectedDiaryContext.tsx
@@ -1,0 +1,50 @@
+import { ICurrentDiaryManager } from '@/model/repository/diaryRepositoryInterfaces';
+import { createContext, useEffect, useState, useContext } from 'react';
+import { container } from 'tsyringe';
+import ContextWrapperProps from './contextWrapperProps';
+
+type SelectedDiaryContextType = {
+  selectedOption: string;
+  setSelectedOption: (val: string) => void;
+  selectCurrentDiary: () => void;
+};
+const SelectedDiaryContext = createContext<SelectedDiaryContextType | null>(
+  null
+);
+export const SelectedDiaryProvider = ({ children }: ContextWrapperProps) => {
+  const [currentDiaryManager, setCurrentDiaryManager] =
+    useState<ICurrentDiaryManager | null>(null);
+  const [selectedOption, setSelectedOption] = useState<string>('');
+  useEffect(() => {
+    const currentDiaryManager = container.resolve<ICurrentDiaryManager>(
+      'ICurrentDiaryManager'
+    );
+    setCurrentDiaryManager(currentDiaryManager);
+  }, []);
+  const selectCurrentDiary = () => {
+    if (currentDiaryManager === null) {
+      return;
+    }
+    setSelectedOption(currentDiaryManager.getCurrentDiaryKey());
+  };
+  const selectedDiaryContextObj = {
+    selectedOption,
+    setSelectedOption,
+    selectCurrentDiary,
+  };
+  return (
+    <SelectedDiaryContext.Provider value={selectedDiaryContextObj}>
+      {children}
+    </SelectedDiaryContext.Provider>
+  );
+};
+
+export const useSelectedDiaryContext = () => {
+  const context = useContext(SelectedDiaryContext);
+  if (context === null) {
+    throw new Error(
+      'useSelectedDiaryContext must be used within a DiaryNameListProvider'
+    );
+  }
+  return context;
+};

--- a/game-diary/src/components/mainContent/header.tsx
+++ b/game-diary/src/components/mainContent/header.tsx
@@ -14,7 +14,7 @@ import {
 const Header = () => {
   const { isDarkMode } = useDarkModeContext();
   const { title, updateTitle } = useDiaryEntryTitleContext();
-  const { clear } = useDiaryEntryResetContext();
+  const { clearEntry: clear } = useDiaryEntryResetContext();
   return (
     <div
       className={`translate-y-1 h-16 mb-2 flex justify-end items-center p-2 gap-2`}

--- a/game-diary/src/components/modals/createModal.tsx
+++ b/game-diary/src/components/modals/createModal.tsx
@@ -1,0 +1,41 @@
+import useCreateNewDiary from 'src/hooks/useCreateNewDiary';
+import { darkInput, lightInput } from '../component_styles';
+import { modal, ModalProps } from './modalProps';
+import Overlay from './overlay';
+
+const createModal = ({ onNavigate, isDarkMode }: ModalProps) => {
+  const { newDiaryName, setNewDiaryName, createNewDiary } = useCreateNewDiary();
+  return (
+    <Overlay onClose={() => onNavigate(modal.Home)} isDarkMode={isDarkMode}>
+      <div className={`modal ${isDarkMode ? 'dark-mode' : ''}`}>
+        <h2 className="text-xl font-bold mb-4">新規作成</h2>
+        <div className=" mp-4 flex flex-col gap-2 items-start w-full">
+          <input
+            type="text"
+            className={`p-2 w-full ${isDarkMode ? darkInput : lightInput}`}
+            placeholder="新しい日記の名前"
+            value={newDiaryName}
+            onChange={(e) => setNewDiaryName(e.target.value)}
+          ></input>
+        </div>
+        <div className="gap-2 flex justify-start mt-4 w-full">
+          <button
+            className={`p-4 pxa-4 py-2 rounded shadow-md active:shadow-none ${isDarkMode ? 'border-gray-600 bg-gray-800 hover:bg-gray-700' : 'border-gray-400 bg-gray-100 hover:bg-gray-200'}`}
+            onClick={createNewDiary}
+          >
+            作成
+          </button>
+          <div className=" flex-1">{/** 空白 */}</div>
+          <button
+            className={`px-4 py-2 rounded shadow-md active:shadow-none ${isDarkMode ? 'border-gray-600 bg-gray-800 hover:bg-gray-700' : 'border-gray-400 bg-gray-100 hover:bg-gray-200'}`}
+            onClick={() => onNavigate(modal.Load)}
+          >
+            戻る
+          </button>
+        </div>
+      </div>
+    </Overlay>
+  );
+};
+
+export default createModal;

--- a/game-diary/src/components/modals/deleteModal.tsx
+++ b/game-diary/src/components/modals/deleteModal.tsx
@@ -1,0 +1,41 @@
+import useDiaryDelete from 'src/hooks/useDIaryDelete';
+import { useSelectedDiaryContext } from '../context/selectedDiaryContext';
+import { modal, ModalProps } from './modalProps';
+import Overlay from './overlay';
+import { useDiaryNameListContext } from '../context/diaryNameListContext';
+
+const deleteModal = ({ onNavigate, isDarkMode }: ModalProps) => {
+  const { selectedOption } = useSelectedDiaryContext();
+  const { deleteDiary } = useDiaryDelete();
+  const { getDiaryName } = useDiaryNameListContext();
+  return (
+    <Overlay onClose={() => onNavigate(modal.Home)} isDarkMode={isDarkMode}>
+      <div className={`modal ${isDarkMode ? 'dark-mode' : ''}`}>
+        <h2 className="text-xl font-bold mb-4">削除</h2>
+        <div className=" mp-4 flex flex-col gap-2 items-start w-full">
+          <p>{getDiaryName(selectedOption)}を削除しますか？</p>
+          <p>※この操作は元に戻せません。</p>
+        </div>
+        <div className="gap-2 flex justify-start mt-4 w-full">
+          <button
+            className="px-4 py-2 shadow-md active:shadow-none bg-red-500 text-white rounded hover:bg-red-600"
+            onClick={() => {
+              deleteDiary(selectedOption);
+              onNavigate(modal.Load);
+            }}
+          >
+            削除
+          </button>
+          <div className=" flex-1">{/** 空白 */}</div>
+          <button
+            className={`p-4 pxa-4 py-2 rounded shadow-md active:shadow-none ${isDarkMode ? 'border-gray-600 bg-gray-800 hover:bg-gray-700' : 'border-gray-400 bg-gray-100 hover:bg-gray-200'}`}
+            onClick={() => onNavigate(modal.Load)}
+          >
+            戻る
+          </button>
+        </div>
+      </div>
+    </Overlay>
+  );
+};
+export default deleteModal;

--- a/game-diary/src/components/modals/loadModal.tsx
+++ b/game-diary/src/components/modals/loadModal.tsx
@@ -3,24 +3,31 @@
 import Overlay from './overlay';
 import { modal, ModalProps } from './modalProps';
 import handleLoad from 'src/hooks/handleLoad';
-import { useState } from 'react';
 import { useDiaryNameListContext } from 'src/components/context/diaryNameListContext';
+import { useSelectedDiaryContext } from 'src/components/context/selectedDiaryContext';
+import { useEffect } from 'react';
 
 const LoadModal = ({ onNavigate, isDarkMode }: ModalProps) => {
-  const [selectedOption, setSelectedOption] = useState<string>('');
-  const { diaryNames } = useDiaryNameListContext();
+  const { diaryNames, refreshDiaryNames } = useDiaryNameListContext();
+  const { selectedOption, setSelectedOption, selectCurrentDiary } =
+    useSelectedDiaryContext();
+  useEffect(() => {
+    refreshDiaryNames();
+    selectCurrentDiary();
+  }, []);
   return (
     <Overlay onClose={() => onNavigate(modal.Home)} isDarkMode={isDarkMode}>
       <h2 className="text-xl font-bold mb-4">ロード</h2>
       <select
         className={`w-full p-2 ${isDarkMode ? 'bg-gray-600' : 'bg-gray-300'}`}
+        value={selectedOption}
         onChange={(e) => {
           setSelectedOption(e.target.value);
         }}
       >
-        {diaryNames.map((keyNamePair) => (
-          <option key={keyNamePair.key} value={keyNamePair.key}>
-            {keyNamePair.name}
+        {diaryNames.map((v) => (
+          <option key={v[0]} value={v[0]}>
+            {v[1]}
           </option>
         ))}
       </select>
@@ -41,7 +48,7 @@ const LoadModal = ({ onNavigate, isDarkMode }: ModalProps) => {
         >
           新規作成
         </button>
-        <div className=" flex-1"></div>
+        <div className=" flex-1">{/** 空白 */}</div>
         <button
           className={`px-4 py-2 rounded shadow-md active:shadow-none ${isDarkMode ? 'border-gray-600 bg-gray-800 hover:bg-gray-700' : 'border-gray-400 bg-gray-100 hover:bg-gray-200'}`}
           onClick={() => {

--- a/game-diary/src/components/sidebar/sidebar.tsx
+++ b/game-diary/src/components/sidebar/sidebar.tsx
@@ -8,6 +8,8 @@ import LoadModal from '../modals/loadModal';
 import { modal } from '../modals/modalProps';
 import { useState } from 'react';
 import { useDarkModeContext } from '../context/darkModeContext';
+import CreateModal from '../modals/createModal';
+import DeleteModal from '../modals/deleteModal';
 const Sidebar = () => {
   const { isDarkMode, setDarkMode } = useDarkModeContext();
   const [showModal, setShowModal] = useState(modal.Home);
@@ -62,6 +64,12 @@ const Sidebar = () => {
         )}
         {showModal === modal.Import && (
           <ImportModal onNavigate={setShowModal} isDarkMode={isDarkMode} />
+        )}
+        {showModal === modal.Create && (
+          <CreateModal onNavigate={setShowModal} isDarkMode={isDarkMode} />
+        )}
+        {showModal === modal.Delete && (
+          <DeleteModal onNavigate={setShowModal} isDarkMode={isDarkMode} />
         )}
       </div>
     </div>

--- a/game-diary/src/hooks/useCreateNewDiary.tsx
+++ b/game-diary/src/hooks/useCreateNewDiary.tsx
@@ -1,0 +1,39 @@
+import {
+  ICreateDiary,
+  IDiaryNameService,
+} from '@/control/controlDiary/controlDiaryInterface';
+import { useEffect, useState } from 'react';
+import toast from 'react-hot-toast';
+import { useDiaryEntryResetContext } from 'src/components/context/diaryEntryContext';
+import { container } from 'tsyringe';
+
+const useCreateNewDiary = () => {
+  const [createDiary, setCreateDiary] = useState<ICreateDiary>();
+  const [newDiaryName, setNewDiaryName] = useState('');
+  const { refreshEntry } = useDiaryEntryResetContext();
+  const [nameService, setNameService] = useState<IDiaryNameService>();
+
+  useEffect(() => {
+    const createDiaryInstance = container.resolve<ICreateDiary>('ICreateDiary');
+    setCreateDiary(createDiaryInstance);
+    const nameServiceInstance =
+      container.resolve<IDiaryNameService>('IDiaryNameService');
+    setNameService(nameServiceInstance);
+  }, []);
+  const createNewDiary = () => {
+    if (
+      createDiary === undefined ||
+      nameService === undefined ||
+      newDiaryName === ''
+    ) {
+      return;
+    }
+    const summary = createDiary.create(newDiaryName);
+    refreshEntry();
+    nameService.updateDiaryName(summary.key, summary.name);
+    toast.success(summary.name + 'を新規作成しました');
+    setNewDiaryName('');
+  };
+  return { newDiaryName, setNewDiaryName, createNewDiary };
+};
+export default useCreateNewDiary;

--- a/game-diary/src/hooks/useDIaryDelete.tsx
+++ b/game-diary/src/hooks/useDIaryDelete.tsx
@@ -1,0 +1,26 @@
+import { IDiaryNameService } from '@/control/controlDiary/controlDiaryInterface';
+import { IDiaryDelete } from '@/model/repository/diaryRepositoryInterfaces';
+import { useEffect, useState } from 'react';
+import { container } from 'tsyringe';
+
+const useDiaryDelete = () => {
+  const [dairyDelete, setDiaryDelete] = useState<IDiaryDelete>();
+  const [nameService, setNameService] = useState<IDiaryNameService>();
+
+  useEffect(() => {
+    const diaryDeleteInstance = container.resolve<IDiaryDelete>('IDiaryDelete');
+    setDiaryDelete(diaryDeleteInstance);
+    const nameServiceInstance =
+      container.resolve<IDiaryNameService>('IDiaryNameService');
+    setNameService(nameServiceInstance);
+  }, []);
+  const deleteDiary = (key: string) => {
+    if (dairyDelete === undefined || nameService === undefined) {
+      return;
+    }
+    dairyDelete.delete(key);
+    nameService.removeDiaryName(key);
+  };
+  return { deleteDiary };
+};
+export default useDiaryDelete;

--- a/game-diary/src/hooks/useExport.tsx
+++ b/game-diary/src/hooks/useExport.tsx
@@ -31,8 +31,8 @@ const useExport = () => {
       return;
     }
     try {
-      const [blob, fileName] = diaryExporter.exportFile();
-      const url = URL.createObjectURL(blob);
+      const { data, fileName } = diaryExporter.exportFile();
+      const url = URL.createObjectURL(data);
       const a = document.createElement('a');
       [a.href, a.download] = [url, fileName];
       a.click();

--- a/game-diary/src/lib/__tests__/__mocks__/mockDiaryKeyMapper.ts
+++ b/game-diary/src/lib/__tests__/__mocks__/mockDiaryKeyMapper.ts
@@ -8,8 +8,8 @@ export class MockDiaryKeyMapper implements IDiaryNameManager {
     return this.diaryNames.size;
   }
 
-  collectDiaryNames(): Array<string> {
-    return Array.from(this.diaryNames.values());
+  collectDiaryNameEntries(): Array<[string, string]> {
+    return Array.from(this.diaryNames.entries());
   }
 
   updateDiaryName(key: string, name: string): boolean {
@@ -33,7 +33,7 @@ export class MockDiaryKeyMapper implements IDiaryNameManager {
     this.currentDiaryKey = key;
   }
 
-  isIncludeDiaryName(name: string): boolean {
+  hasDiaryName(name: string): boolean {
     return Array.from(this.diaryNames.values()).includes(name);
   }
 }

--- a/game-diary/src/lib/__tests__/model/diary/diaryFactory.test.ts
+++ b/game-diary/src/lib/__tests__/model/diary/diaryFactory.test.ts
@@ -28,7 +28,7 @@ describe('DiaryFactory', () => {
     mockSettingsFactory = jest.fn().mockReturnValue(mockSettings);
     mockBuilder = jest.fn().mockReturnValue(mockEntry);
 
-    container.register('DIARY_ENTRIES_CONTAINING_FIRST_DAYFactory', {
+    container.register('NewDiaryEntriesFactory', {
       useValue: mockNewEntriesFactory,
     });
     container.register('NewDiarySettingsFactory', {

--- a/game-diary/src/lib/__tests__/model/diary/diarySettingsFactory.test.ts
+++ b/game-diary/src/lib/__tests__/model/diary/diarySettingsFactory.test.ts
@@ -50,7 +50,7 @@ describe('DiarySettingsFactory - createUseExistingData', () => {
     container.register('IUniqueDiaryNameGenerator', {
       useValue: mockNameGenerator,
     });
-    container.register('DefaultDiaryName', { useValue: diaryName });
+    container.register('DIARY_NAME', { useValue: diaryName });
     container.register('Version', { useValue: version });
 
     diarySettingsFactory = container.resolve(DiarySettingsFactory);

--- a/game-diary/src/lib/__tests__/model/repository/diaryNameManager.test.ts
+++ b/game-diary/src/lib/__tests__/model/repository/diaryNameManager.test.ts
@@ -34,23 +34,31 @@ describe('DiaryNameManager class tests', () => {
     }
   });
   test('DiaryNames init', () => {
-    expect(diaryNameManager.collectDiaryNames()).toMatchObject(diaryNameList);
+    expect(diaryNameManager.collectDiaryNameEntries()).toMatchObject(
+      diaryNameList
+    );
   });
   it('DiaryName add', () => {
     diaryNameManager.updateDiaryName('testKey', 'testName');
     diaryNameList.push('testName');
-    expect(diaryNameManager.collectDiaryNames()).toMatchObject(diaryNameList);
+    expect(diaryNameManager.collectDiaryNameEntries()).toMatchObject(
+      diaryNameList
+    );
   });
   it('DiaryName remove', () => {
     diaryNameManager.removeDiaryName('testKey0');
     diaryNameList.shift();
-    expect(diaryNameManager.collectDiaryNames()).toMatchObject(diaryNameList);
+    expect(diaryNameManager.collectDiaryNameEntries()).toMatchObject(
+      diaryNameList
+    );
   });
   it('DiaryName do not change', () => {
     diaryNameManager.updateDiaryName('', 'testName99');
     diaryNameManager.updateDiaryName('testKey99', '');
     diaryNameManager.updateDiaryName('testKey', '');
-    expect(diaryNameManager.collectDiaryNames()).toMatchObject(diaryNameList);
+    expect(diaryNameManager.collectDiaryNameEntries()).toMatchObject(
+      diaryNameList
+    );
   });
 });
 describe('EmptyStorage DiaryNameManager class tests', () => {
@@ -70,6 +78,6 @@ describe('EmptyStorage DiaryNameManager class tests', () => {
   test('DiaryNames empty', () => {
     const diaryNameManager =
       container.resolve<IDiaryNameManager>('IDiaryNameManager');
-    expect(diaryNameManager.collectDiaryNames()).toMatchObject([]);
+    expect(diaryNameManager.collectDiaryNameEntries()).toMatchObject([]);
   });
 });

--- a/game-diary/src/lib/__tests__/model/repository/uniqueDiaryNameGenerator.test.ts
+++ b/game-diary/src/lib/__tests__/model/repository/uniqueDiaryNameGenerator.test.ts
@@ -11,12 +11,10 @@ describe('UniqueDiaryNameGenerator', () => {
     nameGenerator = new UniqueDiaryNameGenerator(nameManager);
   });
   it('should generate a unique diary name by appending a number if the base name already exists', () => {
-    nameManager.isIncludeDiaryName
-      .mockReturnValueOnce(true)
-      .mockReturnValue(false);
+    nameManager.hasDiaryName.mockReturnValueOnce(true).mockReturnValue(false);
     const result = nameGenerator.generate('diary');
     expect(result).toBe('diary1');
-    expect(nameManager.isIncludeDiaryName).toHaveBeenNthCalledWith(1, 'diary');
-    expect(nameManager.isIncludeDiaryName).toHaveBeenNthCalledWith(2, 'diary1');
+    expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(1, 'diary');
+    expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(2, 'diary1');
   });
 });

--- a/game-diary/src/lib/container/di_diary.ts
+++ b/game-diary/src/lib/container/di_diary.ts
@@ -2,7 +2,6 @@ import { container } from 'tsyringe';
 import {
   IDiary,
   IDiaryFactory,
-  UseExistingDataDiaryFactory,
   IDiaryEntry,
   IDiaryEntryFactory,
   NewDiaryEntriesFactory,
@@ -12,8 +11,6 @@ import {
   IDiarySettings,
   IDiarySettingsFactory,
   DefaultSettingsFactory,
-  NewDiarySettingsFactory,
-  UseExistingDataDiarySettingsFactory,
   IDayModifier,
   UseExistingDataDayModifierFactory,
 } from '@/model/diary/diaryModelInterfaces';
@@ -24,6 +21,7 @@ import {
 import {
   ICurrentDiaryManager,
   IDiaryDataMigrator,
+  IDiaryDelete,
   IDiaryExport,
   IDiaryImport,
   IDiaryLoad,
@@ -60,6 +58,7 @@ import {
   IDiaryExporter,
   IDiaryImporter,
   IDiaryLoadHandler,
+  IDiaryNameService,
   IDiarySaveHandler,
 } from '@/control/controlDiary/controlDiaryInterface';
 import CurrentDiaryAccessor from '@/control/controlDiary/currentDiaryAccessor';
@@ -89,6 +88,8 @@ import {
   compressDiary,
   DiaryDecompressor,
 } from '@/model/serialization/diarySerializer';
+import DiaryNameService from '@/control/controlDiary/diaryNameService';
+import DiaryDelete from '@/model/repository/diaryDelete';
 
 // diaryModelInterfaces
 container.register<UsePreviousDayDiaryEntryFactory>(
@@ -117,10 +118,6 @@ container.register<NewDiaryEntriesFactory>('NewDiaryEntriesFactory', {
 });
 container.register<IDiary>('IDiary', { useClass: Diary });
 container.register<IDiaryFactory>('IDiaryFactory', { useClass: DiaryFactory });
-container.register<UseExistingDataDiaryFactory>('UseExistingDataDiaryFactory', {
-  useFactory: (c) =>
-    c.resolve<IDiaryFactory>('IDiaryFactory').createUseExistingData,
-});
 container.register<IDiaryEntry>('IDiaryEntry', {
   useClass: DiaryEntry,
 });
@@ -171,19 +168,6 @@ container.register<IDiarySettingsFactory>('IDiarySettingsFactory', {
 container.register<DefaultSettingsFactory>('DefaultSettingsFactory', {
   useFactory: (c) => () => c.resolve<IDiarySettings>('IDiarySettings'),
 });
-container.register<NewDiarySettingsFactory>('NewDiarySettingsFactory', {
-  useFactory: (c) =>
-    c.resolve<IDiarySettingsFactory>('IDiarySettingsFactory')
-      .createNewDiarySettings,
-});
-container.register<UseExistingDataDiarySettingsFactory>(
-  'UseExistingDataDiarySettingsFactory',
-  {
-    useFactory: (c) =>
-      c.resolve<IDiarySettingsFactory>('IDiarySettingsFactory')
-        .createUseExistingData,
-  }
-);
 
 container.register<IDayModifier>('IDayModifier', {
   useClass: DayModifier,
@@ -237,11 +221,16 @@ container.registerSingleton<IDiaryImport>('IDiaryImport', DiaryImport);
 container.registerSingleton<IDiaryExport>('IDiaryExport', DiaryExport);
 container.registerSingleton<IDiarySave>('IDiarySave', DiarySave);
 container.registerSingleton<IDiaryLoad>('IDiaryLoad', DiaryLoad);
+container.registerSingleton<IDiaryDelete>('IDiaryDelete', DiaryDelete);
 
 // controlDiaryInterfaces
 container.registerSingleton<ICurrentDiaryAccessor>(
   'ICurrentDiaryAccessor',
   CurrentDiaryAccessor
+);
+container.registerSingleton<IDiaryNameService>(
+  'IDiaryNameService',
+  DiaryNameService
 );
 container.registerSingleton<ICreateDiary>('ICreateDiary', CreateDiary);
 container.registerSingleton<IDeleteDiary>('IDeleteDiary', DeleteDiary);

--- a/game-diary/src/lib/control/controlDiary/controlDiaryInterface.ts
+++ b/game-diary/src/lib/control/controlDiary/controlDiaryInterface.ts
@@ -12,12 +12,59 @@ export interface ICurrentDiaryAccessor {
    */
   setCurrentDiary(key: string): void;
 }
+/**
+ * IDiaryNameManagerを使用して日記名を管理するサービス。
+ * 日記名の取得、更新、削除などの操作を提供する。
+ */
+export interface IDiaryNameService {
+  /** 保存された日記の数を返す */
+  get length(): number;
+  /**
+   * 保存されているストレージキーと日記名の配列を返す。
+   * @returns {Array<[string, string]> } [ストレージキー, 日記名]の配列
+   */
+  collectDiaryNameEntries(): Array<[string, string]>;
+  /**
+   * 指定したストレージキーの日記名を返す。
+   * @param key ストレージキー
+   * @returns {string} 指定したストレージキーの日記名
+   */
+  getDiaryName(key: string): string;
+  /**
+   * ストレージキーを指定して日記名を更新する。新規作成もここで行われる。
+   * 名前が既に存在するときは数字を追加して別の名前にする。
+   * @param key 日記名と対応したストレージキー
+   * @param name 新しい日記名
+   * @returns 保存に成功したならtrue、失敗したならfalse
+   */
+  updateDiaryName(key: string, name: string): boolean;
+  /**
+   * 指定したストレージキーに対応した日記名を日記リストから取り除く。
+   * 日記名だけを取り除き、日記そのものを取り除くことはない。
+   * @param key 取り除く日記のストレージキー
+   */
+  removeDiaryName(key: string): void;
+  /**
+   * 指定した名前がすでに存在するか確認する
+   * @param name 存在するか確認する名前
+   * @returns すでに存在するならtrue、存在しないならfalse
+   */
+  hasDiaryName(name: string): boolean;
+}
+/**
+ * Diaryのデータをカプセル化する型
+ */
+export type DiarySummary = {
+  key: string;
+  name: string;
+};
 /** 新しい日記を作成するクラス */
 export interface ICreateDiary {
   /**
    * カレントの日記から新しい日記を作成する
+   * @returns {DiarySummary} 生成したDIaryのDiarySummary
    */
-  create(): void;
+  create(name: string): DiarySummary;
 }
 export interface IDeleteDiary {
   /**
@@ -43,6 +90,13 @@ export interface IDiaryImporter {
    */
   importFile(file: File): Promise<string>;
 }
+/**
+ * 日記のデータをファイルとして出力するのに必要なデータをやり取りするための型
+ */
+export type ExportFile = {
+  data: Blob;
+  fileName: string;
+};
 /** カレントの日記を出力する */
 export interface IDiaryExporter {
   /**
@@ -55,7 +109,7 @@ export interface IDiaryExporter {
    * 文字列ではなくBlobを返すことで、ファイルとして保存できるようにする。
    * @returns {Blob} Diaryを圧縮したBlob
    */
-  exportFile(): [Blob, string];
+  exportFile(): ExportFile;
 }
 /** カレントの日記をストレージに保存するハンドラ */
 export interface IDiarySaveHandler {

--- a/game-diary/src/lib/control/controlDiary/createDiary.ts
+++ b/game-diary/src/lib/control/controlDiary/createDiary.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from 'tsyringe';
 import type {
+  DiarySummary,
   ICreateDiary,
   ICurrentDiaryAccessor,
 } from './controlDiaryInterface';
@@ -16,10 +17,14 @@ export default class CreateDiary implements ICreateDiary {
     private diaryService: IDiaryService
   ) {}
 
-  create(): void {
+  create(name: string): DiarySummary {
     const oldDiary = this.diaryAccessor.getCurrentDiary();
-    const newDiary = this.diaryFactory.createNewDiary(oldDiary);
+    const newDiary = this.diaryFactory.createNewDiary(oldDiary, name);
     this.diaryService.addDiary(newDiary);
-    this.diaryAccessor.setCurrentDiary(newDiary.getSettings().storageKey);
+    const newName = newDiary.getSettings().getDiaryName();
+
+    const key = newDiary.getSettings().storageKey;
+    this.diaryAccessor.setCurrentDiary(key);
+    return { key, name: newName };
   }
 }

--- a/game-diary/src/lib/control/controlDiary/diaryExporter.ts
+++ b/game-diary/src/lib/control/controlDiary/diaryExporter.ts
@@ -1,5 +1,6 @@
 import { inject, injectable } from 'tsyringe';
 import type {
+  ExportFile,
   ICurrentDiaryAccessor,
   IDiaryExporter,
 } from './controlDiaryInterface';
@@ -16,10 +17,11 @@ export default class DiaryExporter implements IDiaryExporter {
     const diary = this.diaryAccessor.getCurrentDiary();
     return this.diaryExport.export(diary.getSettings().storageKey);
   }
-  exportFile(): [Blob, string] {
+  exportFile(): ExportFile {
     const diary = this.diaryAccessor.getCurrentDiary();
     const fileName = `${diary.getSettings().getDiaryName()}.txt`;
     const exportStr = this.diaryExport.export(diary.getSettings().storageKey);
-    return [new Blob([exportStr], { type: 'text/plain' }), fileName];
+    const data = new Blob([exportStr], { type: 'text/plain' });
+    return { data, fileName };
   }
 }

--- a/game-diary/src/lib/control/controlDiary/diaryNameService.ts
+++ b/game-diary/src/lib/control/controlDiary/diaryNameService.ts
@@ -1,0 +1,31 @@
+import type { IDiaryNameManager } from '@/model/repository/diaryRepositoryInterfaces';
+import { IDiaryNameService } from './controlDiaryInterface';
+import { inject, injectable } from 'tsyringe';
+@injectable()
+export default class DiaryNameService implements IDiaryNameService {
+  constructor(
+    @inject('IDiaryNameManager') private diaryNameManager: IDiaryNameManager
+  ) {}
+
+  get length(): number {
+    return this.diaryNameManager.length;
+  }
+
+  collectDiaryNameEntries(): Array<[string, string]> {
+    return this.diaryNameManager.collectDiaryNameEntries();
+  }
+  getDiaryName(key: string): string {
+    return this.diaryNameManager.getDiaryName(key);
+  }
+  updateDiaryName(key: string, name: string): boolean {
+    return this.diaryNameManager.updateDiaryName(key, name);
+  }
+
+  removeDiaryName(key: string): void {
+    this.diaryNameManager.removeDiaryName(key);
+  }
+
+  hasDiaryName(name: string): boolean {
+    return this.diaryNameManager.hasDiaryName(name);
+  }
+}

--- a/game-diary/src/lib/dairySettingsConstant.ts
+++ b/game-diary/src/lib/dairySettingsConstant.ts
@@ -12,10 +12,12 @@ export default class DairySettingsConstant {
   static readonly CYCLE_PLACEHOLDER: string = '$C';
   static readonly DAY_PLACEHOLDER: string = '$D';
   static readonly TOTAL_DAYS_PLACEHOLDER: string = '$N';
-  /** v0で使用。実際にはストレージキーが入るためv1で修正 */
+  /** v0で使用していたカレントの日記のストレージキーを保存するためのキー。実際にはストレージキーが入るためv1で修正 */
   static readonly CURRENT_GAME_DATA_NAME: string = 'currentGameDataName';
+  /** v1で使用しているカレントの日記のストレージキーを保存するためのキー */
   static readonly CURRENT_DIARY_KEY: string = 'currentDiaryKey';
-  /** v0で使用。名前を変更したためv1で修正 */
+  /** v0で使用していた日記名リストを保存するためのキー。名前を変更したためv1で修正 */
   static readonly GAME_DATA_NAME_LIST: string = 'gameDataNameList';
+  /** v1で使用している日記名リストを保存するためのキー */
   static readonly DIARY_NAME_LIST: string = 'diaryNameList';
 }

--- a/game-diary/src/lib/model/diary/diarySettingsFactory.ts
+++ b/game-diary/src/lib/model/diary/diarySettingsFactory.ts
@@ -20,26 +20,28 @@ export default class DiarySettingsFactory implements IDiarySettingsFactory {
     @inject('StorageKeyFactory') private StorageKeyFactory: StorageKeyFactory,
     @inject('IUniqueDiaryNameGenerator')
     private nameGenerator: IUniqueDiaryNameGenerator,
-    @inject('DefaultDiaryName') private defaultName: string,
-    @inject('Version') private version: number
+    @inject('VERSION') private version: number
   ) {}
+
   createUseExistingData(
     dayModifier: IDayModifier,
     diaryName: string,
     dayInterval: number,
-    storageKey: string,
-    version: number
+    storageKey: string
   ): IDiarySettings {
     return new DiarySettings(
       dayModifier,
       diaryName,
       dayInterval,
       storageKey,
-      version
+      this.version
     );
   }
 
-  createNewDiarySettings(settings?: IDiarySettings): IDiarySettings {
+  createNewDiarySettings(
+    settings?: IDiarySettings,
+    name?: string
+  ): IDiarySettings {
     if (settings === undefined) {
       settings = this.defaultSettingsFactory();
     }
@@ -47,18 +49,19 @@ export default class DiarySettingsFactory implements IDiarySettingsFactory {
     for (let i = 0; i < modifierUnits.length; i++) {
       modifierUnits[i] = settings.getModifierUnit(i);
     }
-
     const newModifier = this.modifierFactory(
       settings.getModifier(),
       settings.getCycleLength(),
       ...modifierUnits
     );
-    const name = this.nameGenerator.generate(this.defaultName);
+    const newName = this.nameGenerator.generate(
+      name ?? settings.getDiaryName()
+    );
     const interval = settings.getDayInterval();
     const storageKey = this.StorageKeyFactory();
     return new DiarySettings(
       newModifier,
-      name,
+      newName,
       interval,
       storageKey,
       this.version

--- a/game-diary/src/lib/model/repository/diaryDelete.ts
+++ b/game-diary/src/lib/model/repository/diaryDelete.ts
@@ -1,0 +1,10 @@
+import { inject, injectable } from 'tsyringe';
+import type { IStorageService } from '../utils/storageServiceInterface';
+import { IDiaryDelete } from './diaryRepositoryInterfaces';
+@injectable()
+export default class DiaryDelete implements IDiaryDelete {
+  constructor(@inject('IStorageService') private storage: IStorageService) {}
+  delete(key: string): void {
+    this.storage.removeItem(key);
+  }
+}

--- a/game-diary/src/lib/model/repository/diaryFactory.ts
+++ b/game-diary/src/lib/model/repository/diaryFactory.ts
@@ -5,17 +5,17 @@ import type {
   IDiaryEntry,
   IDiaryFactory,
   IDiarySettings,
+  IDiarySettingsFactory,
   NewDiaryEntriesFactory,
-  NewDiarySettingsFactory,
   UsePreviousDayDiaryEntryFactory,
 } from '../diary/diaryModelInterfaces';
 @injectable()
 export default class DiaryFactory implements IDiaryFactory {
   constructor(
-    @inject('DIARY_ENTRIES_CONTAINING_FIRST_DAYFactory')
+    @inject('NewDiaryEntriesFactory')
     private newEntriesFactory: NewDiaryEntriesFactory,
-    @inject('NewDiarySettingsFactory')
-    private settingsFactory: NewDiarySettingsFactory,
+    @inject('IDiarySettingsFactory')
+    private settingsFactory: IDiarySettingsFactory,
     @inject('UsePreviousDayDiaryEntryFactory')
     private builder: UsePreviousDayDiaryEntryFactory
   ) {}
@@ -27,13 +27,12 @@ export default class DiaryFactory implements IDiaryFactory {
   ): IDiary {
     return new Diary(this.builder, diaryEntries, settings, lastDay);
   }
-  createNewDiary(diary?: IDiary): IDiary {
+  createNewDiary(diary?: IDiary, name?: string): IDiary {
     const newEntries: Map<number, IDiaryEntry> = this.newEntriesFactory();
-    if (diary === undefined) {
-      const settings = this.settingsFactory();
-      return new Diary(this.builder, newEntries, settings, 1);
-    }
-    const settings = this.settingsFactory(diary.getSettings());
+    const settings = this.settingsFactory.createNewDiarySettings(
+      diary?.getSettings(),
+      name
+    );
     return new Diary(this.builder, newEntries, settings, 1);
   }
 }

--- a/game-diary/src/lib/model/repository/diaryRepositoryInterfaces.ts
+++ b/game-diary/src/lib/model/repository/diaryRepositoryInterfaces.ts
@@ -1,7 +1,8 @@
 import { IDiary } from '@/model/diary/diaryModelInterfaces';
 
 /**
- * Diaryを管理し、Diaryへのアクセスを他クラスに提供する。
+ * Diaryをメモリ上に保管し、取得・追加・削除を行うクラス。
+ * このクラスが持たずにストレージ上にあることはあっても、ストレージが持たずにこのクラスが持つことはない。
  */
 export interface IDiaryService {
   /**
@@ -28,10 +29,16 @@ export interface IDiaryNameManager {
   /** 保存された日記の数を返す */
   get length(): number;
   /**
-   * 保存されている日記名の配列を返す。
-   * @returns {Array<string>} 日記名の配列
+   * 保存されているストレージキーと日記名の配列を返す。
+   * @returns {Array<[string, string]> } [ストレージキー, 日記名]の配列
    */
-  collectDiaryNames(): Array<string>;
+  collectDiaryNameEntries(): Array<[string, string]>;
+  /**
+   * 指定したストレージキーの日記名を返す。
+   * @param key ストレージキー
+   * @returns {string} 指定したストレージキーの日記名
+   */
+  getDiaryName(key: string): string;
   /**
    * ストレージキーを指定して日記名を更新する。新規作成もここで行われる。
    * 名前が既に存在するときは数字を追加して別の名前にする。
@@ -51,7 +58,7 @@ export interface IDiaryNameManager {
    * @param name 存在するか確認する名前
    * @returns すでに存在するならtrue、存在しないならfalse
    */
-  isIncludeDiaryName(name: string): boolean;
+  hasDiaryName(name: string): boolean;
 }
 /**
  * ストレージに保存されたカレントの日記・名前とキーのペアを最新のバージョンに適合させるクラス。
@@ -124,4 +131,14 @@ export interface IDiaryLoad {
    * @throws {KeyNotFoundError} 要素がローカルストレージに存在しない。
    */
   load(key: string): IDiary;
+}
+/**
+ * 受け取ったKeyのDiaryをストレージから削除する。
+ */
+export interface IDiaryDelete {
+  /**
+   * 指定したKeyのDiaryをストレージから削除する。
+   * @param {string} key 削除する日記のキー
+   */
+  delete(key: string): void;
 }

--- a/game-diary/src/lib/model/repository/diaryService.ts
+++ b/game-diary/src/lib/model/repository/diaryService.ts
@@ -1,37 +1,28 @@
-import { inject, injectable, singleton } from 'tsyringe';
-import type {
-  IsStorageAvailableFunc,
-  IStorageService,
-} from '@/model/utils/storageServiceInterface';
+import { inject, injectable } from 'tsyringe';
 import type { IDiary } from '@/model/diary/diaryModelInterfaces';
-import type { IDiaryService } from './diaryRepositoryInterfaces';
-/**
- * 全ての日記を管理するクラス。
- */
-@singleton()
+import type {
+  IDiaryDelete,
+  IDiarySave,
+  IDiaryService,
+} from './diaryRepositoryInterfaces';
 @injectable()
 export default class DiaryService implements IDiaryService {
   private diaries: Map<string, IDiary> = new Map();
   constructor(
-    @inject('IStorageService')
-    private storage: IStorageService,
-    @inject('IsStorageAvailableFunc')
-    private isStorageAvailable: IsStorageAvailableFunc
+    @inject('IDiarySave')
+    private diarySave: IDiarySave,
+    @inject('IDiaryDelete')
+    private diaryDelete: IDiaryDelete
   ) {}
   getDiary(key: string): IDiary | undefined {
     return this.diaries.get(key);
   }
   addDiary(diary: IDiary): void {
     this.diaries.set(diary.getSettings().storageKey, diary);
-    if (this.isStorageAvailable(this.storage)) {
-      this.storage.setItem(
-        diary.getSettings().storageKey,
-        JSON.stringify(diary)
-      );
-    }
+    this.diarySave.save(diary);
   }
   deleteDiary(key: string): void {
     this.diaries.delete(key);
-    this.storage.removeItem(key);
+    this.diaryDelete.delete(key);
   }
 }

--- a/game-diary/src/lib/model/repository/uniqueDiaryNameGenerator.ts
+++ b/game-diary/src/lib/model/repository/uniqueDiaryNameGenerator.ts
@@ -1,20 +1,18 @@
 import { inject, injectable } from 'tsyringe';
-import type {
-  IDiaryNameManager,
-  IUniqueDiaryNameGenerator,
-} from './diaryRepositoryInterfaces';
+import { IUniqueDiaryNameGenerator } from './diaryRepositoryInterfaces';
+import type { IDiaryNameService } from '@/control/controlDiary/controlDiaryInterface';
 @injectable()
 export default class UniqueDiaryNameGenerator
   implements IUniqueDiaryNameGenerator
 {
   constructor(
-    @inject('IDiaryNameManager') private diaryKeyMapper: IDiaryNameManager
+    @inject('IDiaryNameService') private diaryNameService: IDiaryNameService
   ) {}
   generate(name: string): string {
     // 日記名に重複がないか調べる。重複している場合は数字を付加して重複を避ける。
     let newName: string = name;
     let i: number = 1;
-    while (this.diaryKeyMapper.isIncludeDiaryName(newName)) {
+    while (this.diaryNameService.hasDiaryName(newName)) {
       newName = name + String(i);
       i++;
     }

--- a/game-diary/src/lib/model/serialization/decompressVersion00.ts
+++ b/game-diary/src/lib/model/serialization/decompressVersion00.ts
@@ -1,12 +1,12 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
 import { InvalidJsonError } from '@/error';
 import {
   UseExistingDataDayModifierFactory,
-  UseExistingDataDiaryFactory,
-  UseExistingDataDiarySettingsFactory,
+  
   IDiary,
   IDiaryEntry,
   UseExistingDataDiaryEntryFactory,
+  IDiarySettingsFactory,
+  IDiaryFactory,
 } from '../diary/diaryModelInterfaces';
 import { hasField, isArrayType, isTypeMatch } from '../utils/checkTypeMatch';
 
@@ -19,9 +19,9 @@ import { hasField, isArrayType, isTypeMatch } from '../utils/checkTypeMatch';
 export function decompressVersion00(
   jsonObj: object,
   dayModifierFactory: UseExistingDataDayModifierFactory,
-  diarySettingsFactory: UseExistingDataDiarySettingsFactory,
+  diarySettingsFactory: IDiarySettingsFactory,
   diaryEntryFactory: UseExistingDataDiaryEntryFactory,
-  diaryFactory: UseExistingDataDiaryFactory
+  diaryFactory: IDiaryFactory
 ): IDiary {
   if (!hasField(jsonObj, 'lastDay', 'number')) {
     throw new InvalidJsonError('Diary class is broken');
@@ -47,12 +47,11 @@ export function decompressVersion00(
     jsonObj.settings.unitOfDay.unit[3],
     jsonObj.settings.unitOfDay.unit[4]
   );
-  const settings = diarySettingsFactory(
+  const settings = diarySettingsFactory.createUseExistingData(
     dayModifier,
     jsonObj.settings.playGamedataName,
     jsonObj.settings.dayInterval,
-    jsonObj.settings.storageKey,
-    DairySettingsConstant.CURRENT_VERSION
+    jsonObj.settings.storageKey
   );
   if (!hasField(jsonObj, 'dayReports', 'Array')) {
     throw new InvalidJsonError('Array<DayReport> class is broken');
@@ -80,5 +79,5 @@ export function decompressVersion00(
     );
     map.set(diary.day, diary);
   }
-  return diaryFactory(map, settings, jsonObj.lastDay);
+  return diaryFactory.createUseExistingData(map, settings, jsonObj.lastDay);
 }

--- a/game-diary/src/lib/model/serialization/decompressVersion01.ts
+++ b/game-diary/src/lib/model/serialization/decompressVersion01.ts
@@ -1,21 +1,20 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
 import { InvalidJsonError } from '@/error';
 import { hasField, isArrayType, isTypeMatch } from '../utils/checkTypeMatch';
 import {
   UseExistingDataDayModifierFactory,
-  UseExistingDataDiaryFactory,
-  UseExistingDataDiarySettingsFactory,
   IDiary,
   IDiaryEntry,
   UseExistingDataDiaryEntryFactory,
+  IDiarySettingsFactory,
+  IDiaryFactory,
 } from '../diary/diaryModelInterfaces';
 
 export function decompressVersion01(
   jsonObj: object,
   dayModifierFactory: UseExistingDataDayModifierFactory,
-  diarySettingsFactory: UseExistingDataDiarySettingsFactory,
+  diarySettingsFactory: IDiarySettingsFactory,
   diaryEntryFactory: UseExistingDataDiaryEntryFactory,
-  diaryFactory: UseExistingDataDiaryFactory
+  diaryFactory: IDiaryFactory
 ): IDiary {
   if (!hasField(jsonObj, 'lastDay', 'number')) {
     throw new InvalidJsonError('Reports class is broken');
@@ -44,12 +43,11 @@ export function decompressVersion01(
     jsonObj.settings.dayModifier.cycleLength,
     ...jsonObj.settings.dayModifier.unit
   );
-  const settings = diarySettingsFactory(
+  const settings = diarySettingsFactory.createUseExistingData(
     dayModifier,
     jsonObj.settings.diaryName,
     jsonObj.settings.dayInterval,
-    jsonObj.settings._storageKey,
-    DairySettingsConstant.CURRENT_VERSION
+    jsonObj.settings._storageKey
   );
   if (!hasField(jsonObj, 'diaryEntries', 'Array')) {
     throw new InvalidJsonError('Array<DayReport> class is broken');
@@ -81,5 +79,5 @@ export function decompressVersion01(
     );
     map.set(diary.day, diary);
   }
-  return diaryFactory(map, settings, jsonObj.lastDay);
+  return diaryFactory.createUseExistingData(map, settings, jsonObj.lastDay);
 }

--- a/game-diary/src/lib/model/serialization/diarySerializer.ts
+++ b/game-diary/src/lib/model/serialization/diarySerializer.ts
@@ -12,10 +12,10 @@ import { decompressVersion00 } from './decompressVersion00';
 import { decompressVersion01 } from './decompressVersion01';
 import type {
   UseExistingDataDayModifierFactory,
-  UseExistingDataDiaryFactory,
-  UseExistingDataDiarySettingsFactory,
   IDiary,
   UseExistingDataDiaryEntryFactory,
+  IDiarySettingsFactory,
+  IDiaryFactory,
 } from '../diary/diaryModelInterfaces';
 import { inject, injectable } from 'tsyringe';
 
@@ -34,12 +34,12 @@ export class DiaryDecompressor {
   constructor(
     @inject('UseExistingDataDayModifierFactory')
     private dayModifierFactory: UseExistingDataDayModifierFactory,
-    @inject('UseExistingDataDiarySettingsFactory')
-    private diarySettingsFactory: UseExistingDataDiarySettingsFactory,
+    @inject('IDiarySettingsFactory')
+    private diarySettingsFactory: IDiarySettingsFactory,
     @inject('UseExistingDataDiaryEntryFactory')
     private diaryEntryFactory: UseExistingDataDiaryEntryFactory,
-    @inject('UseExistingDataDiaryFactory')
-    private diaryFactory: UseExistingDataDiaryFactory
+    @inject('IDiaryFactory')
+    private diaryFactory: IDiaryFactory
   ) {}
   /**
    * 圧縮されたJSONをIDiaryに変換して返却する。
@@ -49,7 +49,7 @@ export class DiaryDecompressor {
   decompressDiary(compressed: string): IDiary {
     const decompress = decompressFromEncodedURIComponent(compressed);
     if (decompress === null) {
-      throw new DecompressionError('Could not decompress');
+      throw new DecompressionError(`Could not decompress: ${compressed}`);
     }
     const jsonObj: unknown = JSON.parse(decompress);
     if (!isTypeMatch(jsonObj, 'object')) {


### PR DESCRIPTION
 fix #167
- 日記削除処理を行うための useDiaryDelete フックを追加
- ストレージからの日記削除を管理する DiaryDelete クラスを導入
- 日記名の管理操作をカプセル化する DiaryNameService を作成
- 日記名管理用のメソッドを含むように IDiaryNameManager インターフェースを更新
- UniqueDiaryNameGenerator を IDiaryNameService を利用する形にリファクタリング
- DiaryFactory および DiarySettingsFactory を、名前付きの日記作成に対応するよう変更
- 日記設定および日記名の変更に対応するため、シリアライズ／デシリアライズ処理を調整
- 可読性と一貫性向上のため、複数のメソッドおよびインターフェースの名称変更とリファクタリングを実施