### PR TITLE
feat: カレントの日記を削除した際に使い方の日記を読み込む

### DIFF
--- a/game-diary/src/components/context/appInitProvider.tsx
+++ b/game-diary/src/components/context/appInitProvider.tsx
@@ -8,14 +8,16 @@ import '@/container/di_diary';
 import { container } from 'tsyringe';
 import { useEffect, useState } from 'react';
 import ContextWrapperProps from './contextWrapperProps';
-import {
-  ICreateDiary,
-  IDiaryImporter,
-  IDiaryLoadHandler,
-} from '@/control/controlDiary/controlDiaryInterface';
+import useFetchHowToUse from 'src/hooks/useFetchHowToUse';
 
 const AppInitProvider = ({ children }: ContextWrapperProps) => {
   const [isReady, setIsReady] = useState(false);
+  const { isRead, useReadHowToUse } = useFetchHowToUse();
+  useEffect(() => {
+    if (!isReady && isRead) {
+      setIsReady(true);
+    }
+  }, [isRead]);
   useEffect(() => {
     container.register<Storage>('LocalStorage', {
       useValue: window.localStorage,
@@ -29,22 +31,11 @@ const AppInitProvider = ({ children }: ContextWrapperProps) => {
       setIsReady(true);
       return;
     }
-    const path = container.resolve<string>('HOW_TO_TEXT_URL');
-    fetch(path)
-      .then((res) => {
-        if (!res.ok) {
-          const createDiary = container.resolve<ICreateDiary>('ICreateDiary');
-          createDiary.createDefaultDiary();
-          setIsReady(true);
-          throw new Error('使い方.txtの読み込みに失敗しました:' + path);
-        }
-        return res.text();
-      })
-      .then((data) => {
-        const importer = container.resolve<IDiaryImporter>('IDiaryImporter');
-        importer.importText(data);
-      })
-      .then(() => setIsReady(true));
+    try {
+      useReadHowToUse();
+    } catch (e) {
+      console.error(e);
+    }
   }, []);
   if (!isReady) {
     return <div>Loading...</div>;

--- a/game-diary/src/components/modals/loadModal.tsx
+++ b/game-diary/src/components/modals/loadModal.tsx
@@ -18,10 +18,11 @@ const LoadModal = () => {
   const { go, shortcutRegister } = useModalContext();
   const pulldownMenu = useRef<HTMLSelectElement>(null);
   useEffect(() => {
-    setTimeout(() => selectCurrentDiary(), 0);
-    setTimeout(() => refreshDiary(), 0);
-    setTimeout(() => pulldownMenu.current?.focus(), 0);
+    selectCurrentDiary();
+    refreshDiary();
+    pulldownMenu.current?.focus();
   }, [selectCurrentDiary, refreshDiary, pulldownMenu]);
+
   useEffect(() => {
     const unregister = shortcutRegister((e) => {
       if (

--- a/game-diary/src/hooks/useDIaryDelete.tsx
+++ b/game-diary/src/hooks/useDIaryDelete.tsx
@@ -2,22 +2,33 @@
 import { IDeleteDiary } from '@/control/controlDiary/controlDiaryInterface';
 import { useCallback, useEffect, useState } from 'react';
 import { container } from 'tsyringe';
+import useFetchHowToUse from './useFetchHowToUse';
+import useRefreshCurrentDiary from './useRefreshCurrentDiary';
+import { useSelectedDiaryContext } from 'src/components/context/selectedDiaryContext';
 
 const useDiaryDelete = () => {
   const [dairyDelete, setDiaryDelete] = useState<IDeleteDiary>();
-
+  const { useReadHowToUse } = useFetchHowToUse();
+  const { refreshCurrentDiary } = useRefreshCurrentDiary();
+  const { selectCurrentDiary } = useSelectedDiaryContext();
   useEffect(() => {
     const diaryDeleteInstance = container.resolve<IDeleteDiary>('IDeleteDiary');
     setDiaryDelete(diaryDeleteInstance);
   }, []);
   const deleteDiary = useCallback(
-    (key: string) => {
+    async (key: string) => {
       if (dairyDelete === undefined) {
         return;
       }
-      dairyDelete.delete(key);
+      const isDeleted = dairyDelete.delete(key);
+      if (!isDeleted) {
+        await useReadHowToUse();
+        dairyDelete.delete(key);
+      }
+      refreshCurrentDiary();
+      selectCurrentDiary();
     },
-    [dairyDelete]
+    [dairyDelete, useReadHowToUse, refreshCurrentDiary, selectCurrentDiary]
   );
   return { deleteDiary };
 };

--- a/game-diary/src/hooks/useFetchHowToUse.tsx
+++ b/game-diary/src/hooks/useFetchHowToUse.tsx
@@ -1,0 +1,41 @@
+import {
+  ICreateDiary,
+  IDiaryImporter,
+  IDiaryLoadHandler,
+} from '@/control/controlDiary/controlDiaryInterface';
+import { useCallback, useState } from 'react';
+import { container } from 'tsyringe';
+
+const useFetchHowToUse = () => {
+  const [isRead, setIsRead] = useState(false);
+
+  const fetchHowToUse = useCallback(async () => {
+    const path = container.resolve<string>('HOW_TO_USE_TEXT_URL');
+    const res = await fetch(path);
+
+    if (!res.ok) {
+      const createDiary = container.resolve<ICreateDiary>('ICreateDiary');
+      createDiary.createDefaultDiary();
+      setIsRead(true);
+      throw new Error('使い方の読み込みに失敗しました:' + path);
+    }
+    const data = await res.text();
+    const importer = container.resolve<IDiaryImporter>('IDiaryImporter');
+    importer.importText(data);
+    setIsRead(true);
+  }, []);
+  const useReadHowToUse = useCallback(async (): Promise<void> => {
+    const loader = container.resolve<IDiaryLoadHandler>('IDiaryLoadHandler');
+    try {
+      await Promise.resolve(
+        loader.load(container.resolve<string>('HOW_TO_USE_KEY'))
+      );
+      setIsRead(true);
+    } catch (e) {
+      await fetchHowToUse();
+    }
+  }, [fetchHowToUse]);
+  return { isRead, useReadHowToUse, fetchHowToUse };
+};
+
+export default useFetchHowToUse;

--- a/game-diary/src/lib/container/di_diary.ts
+++ b/game-diary/src/lib/container/di_diary.ts
@@ -127,8 +127,11 @@ container.register<string>('DEFAULT_TITLE', {
     String(container.resolve<number>('FIRST_DAY')) +
     DairySettingsConstant.DEFAULT_DAY_MODIFIER,
 });
-container.register<string>('HOW_TO_TEXT_URL', {
-  useValue: DairySettingsConstant.HOW_TO_TEXT_URL,
+container.register<string>('HOW_TO_USE_TEXT_URL', {
+  useValue: DairySettingsConstant.HOW_TO_USE_TEXT_URL,
+});
+container.register<string>('HOW_TO_USE_KEY', {
+  useValue: DairySettingsConstant.HOW_TO_USE_KEY,
 });
 container.register<string>('EMPTY_STRING', { useValue: '' });
 container.register<undefined>('UNDEFINED', { useFactory: () => undefined });

--- a/game-diary/src/lib/dairySettingsConstant.ts
+++ b/game-diary/src/lib/dairySettingsConstant.ts
@@ -23,5 +23,9 @@ export default class DairySettingsConstant {
   /** v1で使用している日記名リストを保存するためのキー */
   static readonly DIARY_NAME_LIST: string = 'diaryNameList';
 
-  static readonly HOW_TO_TEXT_URL: string = './使い方.txt';
+  /** 使い方の日記データが保存されているテキストファイルのURL */
+  static readonly HOW_TO_USE_TEXT_URL: string = './使い方.txt';
+  /** 使い方の日記データを読み取るためのストレージキー */
+  static readonly HOW_TO_USE_KEY: string =
+    '862c89fc-908c-439d-8443-db7d29ab25c5';
 }

--- a/game-diary/src/lib/model/repository/diaryImport.ts
+++ b/game-diary/src/lib/model/repository/diaryImport.ts
@@ -10,7 +10,6 @@ export default class DiaryImport implements IDiaryImport {
     @inject('IDiaryNameService') private diaryNameService: IDiaryNameService
   ) {}
   import(val: string): string {
-    console.log('pass DiaryImport');
     const diary = this.diaryDecompressor.decompressDiary(val);
     this.diaryService.addDiary(diary);
     this.diaryNameService.updateDiaryName(

--- a/game-diary/src/lib/model/repository/diaryLoad.ts
+++ b/game-diary/src/lib/model/repository/diaryLoad.ts
@@ -18,7 +18,7 @@ export default class DiaryLoad implements IDiaryLoad {
     }
     const diaryStr = this.storage.getItem(key);
     if (diaryStr === null) {
-      throw new KeyNotFoundError(`Key ${key} not found`);
+      throw new KeyNotFoundError(`Key "${key}" not found`);
     }
     const decompressedDiary = this.diaryDecompressor.decompressDiary(diaryStr);
     this.diaryService.addDiary(decompressedDiary);


### PR DESCRIPTION
- appInitProvider.tsx 使い方の読み込みを抽出
- loadModal.tsx 不要なディレイの削除
- useDiaryDelete.tsx カレントの日記を削除した際に使い方の日記を読み込むように修正
- useFetchHowToUse.tsx 使い方を読み込む関数を作成
- diarySettingsContstant.ts 使い方のストレージキーを定数に追加
- di_diary.ts 使い方のストレージキーをコンテナに追加
- diaryImport.ts 不要なconsole.logを削除
- diaryLoad.ts KeyNotFoundErrorでkeyが空文字だったときにわかりやすいようにダブルクォーテーションを追加
Fixes #182