### PR TITLE
feat: インポート・ロード時に重複した名前がある場合、異なる名前をつける

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,19 +5,19 @@
       "type": "node",
       "request": "launch",
       "name": "Debug Jest Tests",
-      "program": "${workspaceFolder}/game-diary/node_modules/.bin/jest",
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
       "args": [
         "--runInBand",
         "--watchAll",
         "--config",
-        "${workspaceFolder}/game-diary/jest.config.js"
+        "${workspaceFolder}/jest.config.js"
       ],
       "internalConsoleOptions": "openOnSessionStart",
       "skipFiles": ["<node_internals>/**"],
-      "cwd": "${workspaceFolder}/game-diary",
+      "cwd": "${workspaceFolder}",
       "runtimeArgs": [
         "--require",
-        "${workspaceFolder}/game-diary/node_modules/ts-node/register"
+        "${workspaceFolder}/node_modules/ts-node/register"
       ],
       "console": "integratedTerminal",
       "outputCapture": "std"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,6 @@
 
   "plantuml.server": "http://plantuml-server:8080",
   "plantuml.render": "PlantUMLServer",
-  "prettier.configPath": "./game-diary/.prettierrc",
+  "prettier.configPath": "./.prettierrc",
   "cSpell.words": ["enduml", "Hoge", "startuml", "tsyringe"]
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "lz-string": "^1.5.0",

--- a/src/lib/__tests__/model/repository/uniqueDiaryNameGenerator.test.ts
+++ b/src/lib/__tests__/model/repository/uniqueDiaryNameGenerator.test.ts
@@ -6,7 +6,8 @@ describe('UniqueDiaryNameGenerator', () => {
   let nameGenerator: UniqueDiaryNameGenerator;
   beforeEach(() => {
     nameManager = {
-      isIncludeDiaryName: jest.fn(),
+      hasDiaryName: jest.fn(),
+      getDiaryName: jest.fn(),
     } as unknown as jest.Mocked<IDiaryNameManager>;
     nameGenerator = new UniqueDiaryNameGenerator(nameManager);
   });
@@ -16,5 +17,37 @@ describe('UniqueDiaryNameGenerator', () => {
     expect(result).toBe('diary1');
     expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(1, 'diary');
     expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(2, 'diary1');
+  });
+  it('should return the original name if it is unique', () => {
+    nameManager.hasDiaryName.mockReturnValue(false);
+    const result = nameGenerator.generate('uniqueDiary');
+    expect(result).toBe('uniqueDiary');
+    expect(nameManager.hasDiaryName).toHaveBeenCalledWith('uniqueDiary');
+  });
+  it('should return the original name if the key corresponds to the same name', () => {
+    nameManager.getDiaryName.mockReturnValue('myDiary');
+    const result = nameGenerator.generate('myDiary', 'someKey');
+    expect(result).toBe('myDiary');
+    expect(nameManager.getDiaryName).toHaveBeenCalledWith('someKey');
+  });
+  it('should generate a unique name when multiple duplicates exist', () => {
+    nameManager.hasDiaryName
+      .mockReturnValueOnce(true)
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+    const result = nameGenerator.generate('diary');
+    expect(result).toBe('diary2');
+    expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(1, 'diary');
+    expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(2, 'diary1');
+    expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(3, 'diary2');
+  });
+  it('should generate a unique name if the name associated with the key differs from the provided name', () => {
+    nameManager.getDiaryName.mockReturnValue('oldDiary');
+    nameManager.hasDiaryName.mockReturnValueOnce(true).mockReturnValue(false);
+    const result = nameGenerator.generate('newDiary', 'someKey');
+    expect(result).toBe('newDiary1');
+    expect(nameManager.getDiaryName).toHaveBeenCalledWith('someKey');
+    expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(1, 'newDiary');
+    expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(2, 'newDiary1');
   });
 });

--- a/src/lib/control/controlDiary/controlDiaryInterface.ts
+++ b/src/lib/control/controlDiary/controlDiaryInterface.ts
@@ -31,13 +31,21 @@ export interface IDiaryNameService {
    */
   getDiaryName(key: string): string;
   /**
-   * ストレージキーを指定して日記名を更新する。新規作成もここで行われる。
+   * ストレージキーを指定して日記名を追加する。updateDiaryNameと同様の動作をする。
    * 名前が既に存在するときは数字を追加して別の名前にする。
    * @param key 日記名と対応したストレージキー
    * @param name 新しい日記名
-   * @returns 保存に成功したならtrue、失敗したならfalse
+   * @returns 一意であることが保証された新しい日記名
    */
-  updateDiaryName(key: string, name: string): boolean;
+  addDiaryName(key: string, name: string): string;
+  /**
+   * ストレージキーを指定して日記名を更新する。
+   * 名前が既に存在するときは数字を追加して別の名前にする。
+   * @param key 日記名と対応したストレージキー
+   * @param name 新しい日記名
+   * @returns 一意であることが保証された新しい日記名
+   */
+  updateDiaryName(key: string, name: string): string;
   /**
    * 指定したストレージキーに対応した日記名を日記リストから取り除く。
    * 日記名だけを取り除き、日記そのものを取り除くことはない。

--- a/src/lib/control/controlDiary/diaryNameService.ts
+++ b/src/lib/control/controlDiary/diaryNameService.ts
@@ -1,10 +1,15 @@
-import type { IDiaryNameManager } from '@/model/repository/diaryRepositoryInterfaces';
+import type {
+  IDiaryNameManager,
+  IUniqueDiaryNameGenerator,
+} from '@/model/repository/diaryRepositoryInterfaces';
 import { IDiaryNameService } from './controlDiaryInterface';
 import { inject, injectable } from 'tsyringe';
 @injectable()
 export default class DiaryNameService implements IDiaryNameService {
   constructor(
-    @inject('IDiaryNameManager') private diaryNameManager: IDiaryNameManager
+    @inject('IDiaryNameManager') private diaryNameManager: IDiaryNameManager,
+    @inject('IUniqueDiaryNameGenerator')
+    private nameGenerator: IUniqueDiaryNameGenerator
   ) {}
 
   get length(): number {
@@ -17,8 +22,13 @@ export default class DiaryNameService implements IDiaryNameService {
   getDiaryName(key: string): string {
     return this.diaryNameManager.getDiaryName(key);
   }
-  updateDiaryName(key: string, name: string): boolean {
-    return this.diaryNameManager.updateDiaryName(key, name);
+  addDiaryName(key: string, name: string): string {
+    return this.updateDiaryName(key, name);
+  }
+  updateDiaryName(key: string, name: string): string {
+    const uniqueName = this.nameGenerator.generate(name, key);
+    this.diaryNameManager.updateDiaryName(key, uniqueName);
+    return uniqueName;
   }
 
   removeDiaryName(key: string): void {

--- a/src/lib/control/controlDiary/editDiarySettings.ts
+++ b/src/lib/control/controlDiary/editDiarySettings.ts
@@ -12,13 +12,12 @@ export default class EditDiarySettings implements IEditDiarySettings {
     @inject('IDiaryNameService')
     private diaryNameService: IDiaryNameService
   ) {}
-  editDiaryName(name: string): boolean {
-    this.getSettings().setDiaryName(name);
-    const isEdited = this.diaryNameService.updateDiaryName(
+  editDiaryName(name: string): void {
+    const uniqueName = this.diaryNameService.updateDiaryName(
       this.getSettings().storageKey,
       name
     );
-    return isEdited;
+    this.getSettings().setDiaryName(uniqueName);
   }
   editDayInterval(interval: number): void {
     this.getSettings().updateDayInterval(interval);

--- a/src/lib/control/controlDiaryEntry/controlDiaryEntryInterface.ts
+++ b/src/lib/control/controlDiaryEntry/controlDiaryEntryInterface.ts
@@ -47,7 +47,7 @@ export interface IEditDiarySettings {
    * 日記の名前を変更する
    * @param name 日記の名前
    */
-  editDiaryName(name: string): boolean;
+  editDiaryName(name: string): void;
   /**
    * 日記の間隔を変更する
    * @param interval 日記の間隔

--- a/src/lib/model/diary/diarySettingsFactory.ts
+++ b/src/lib/model/diary/diarySettingsFactory.ts
@@ -8,7 +8,6 @@ import type {
 } from './diaryModelInterfaces';
 import DiarySettings from './diarySettings';
 import { inject, injectable } from 'tsyringe';
-import type { IUniqueDiaryNameGenerator } from '../repository/diaryRepositoryInterfaces';
 
 @injectable()
 export default class DiarySettingsFactory implements IDiarySettingsFactory {
@@ -18,8 +17,6 @@ export default class DiarySettingsFactory implements IDiarySettingsFactory {
     @inject('UseExistingDataDayModifierFactory')
     private modifierFactory: UseExistingDataDayModifierFactory,
     @inject('StorageKeyFactory') private StorageKeyFactory: StorageKeyFactory,
-    @inject('IUniqueDiaryNameGenerator')
-    private nameGenerator: IUniqueDiaryNameGenerator,
     @inject('VERSION') private version: number
   ) {}
 
@@ -54,14 +51,11 @@ export default class DiarySettingsFactory implements IDiarySettingsFactory {
       settings.getCycleLength(),
       ...modifierUnits
     );
-    const newName = this.nameGenerator.generate(
-      name ?? settings.getDiaryName()
-    );
     const interval = settings.getDayInterval();
     const storageKey = this.StorageKeyFactory();
     return new DiarySettings(
       newModifier,
-      newName,
+      name ?? settings.getDiaryName(),
       interval,
       storageKey,
       this.version

--- a/src/lib/model/repository/diaryImport.ts
+++ b/src/lib/model/repository/diaryImport.ts
@@ -12,10 +12,11 @@ export default class DiaryImport implements IDiaryImport {
   import(val: string): string {
     const diary = this.diaryDecompressor.decompressDiary(val);
     this.diaryService.addDiary(diary);
-    this.diaryNameService.updateDiaryName(
+    const uniqueName = this.diaryNameService.updateDiaryName(
       diary.getSettings().storageKey,
       diary.getSettings().getDiaryName()
     );
+    diary.getSettings().setDiaryName(uniqueName);
     return diary.getSettings().storageKey;
   }
 }

--- a/src/lib/model/repository/diaryLoad.ts
+++ b/src/lib/model/repository/diaryLoad.ts
@@ -4,12 +4,14 @@ import type { IDiaryDecompressor } from '../serialization/serializationInterface
 import type { IStorageService } from '../utils/storageServiceInterface';
 import type { IDiaryLoad, IDiaryService } from './diaryRepositoryInterfaces';
 import { inject, injectable } from 'tsyringe';
+import type { IDiaryNameService } from '@/control/controlDiary/controlDiaryInterface';
 @injectable()
 export default class DiaryLoad implements IDiaryLoad {
   constructor(
     @inject('IDiaryService') private diaryService: IDiaryService,
     @inject('IStorageService') private storage: IStorageService,
-    @inject('IDiaryDecompressor') private diaryDecompressor: IDiaryDecompressor
+    @inject('IDiaryDecompressor') private diaryDecompressor: IDiaryDecompressor,
+    @inject('IDiaryNameService') private diaryNameService: IDiaryNameService
   ) {}
   load(key: string): IDiary {
     const diary = this.diaryService.getDiary(key);
@@ -21,6 +23,11 @@ export default class DiaryLoad implements IDiaryLoad {
       throw new KeyNotFoundError(`Key "${key}" not found`);
     }
     const decompressedDiary = this.diaryDecompressor.decompressDiary(diaryStr);
+    const uniqueName = this.diaryNameService.updateDiaryName(
+      decompressedDiary.getSettings().storageKey,
+      decompressedDiary.getSettings().getDiaryName()
+    );
+    decompressedDiary.getSettings().setDiaryName(uniqueName);
     this.diaryService.addDiary(decompressedDiary);
     return decompressedDiary;
   }

--- a/src/lib/model/repository/diaryRepositoryInterfaces.ts
+++ b/src/lib/model/repository/diaryRepositoryInterfaces.ts
@@ -71,14 +71,15 @@ export interface IDiaryDataMigrator {
   migrate(): void;
 }
 
-/** 日記名がユニークな名前であることを保証するクラス */
+/** ユニークな日記名を生成するクラス */
 export interface IUniqueDiaryNameGenerator {
   /**
    * 受け取った名前をユニークな名前に変換して返却する。
    * @param {string} name ユニークにしたい名前
+   * @param {string} [key] 既存の日記のキー（更新時に使用）
    * @returns {string} ユニークな名前
    */
-  generate(name: string): string;
+  generate(name: string, key?: string): string;
 }
 /** カレントのDiaryがどのDiaryであるかKeyで管理するクラス */
 export interface ICurrentDiaryManager {

--- a/src/lib/model/repository/uniqueDiaryNameGenerator.ts
+++ b/src/lib/model/repository/uniqueDiaryNameGenerator.ts
@@ -1,18 +1,24 @@
 import { inject, injectable } from 'tsyringe';
-import { IUniqueDiaryNameGenerator } from './diaryRepositoryInterfaces';
-import type { IDiaryNameService } from '@/control/controlDiary/controlDiaryInterface';
+import type {
+  IDiaryNameManager,
+  IUniqueDiaryNameGenerator,
+} from './diaryRepositoryInterfaces';
 @injectable()
 export default class UniqueDiaryNameGenerator
   implements IUniqueDiaryNameGenerator
 {
   constructor(
-    @inject('IDiaryNameService') private diaryNameService: IDiaryNameService
+    @inject('IDiaryNameManager') private diaryNameManager: IDiaryNameManager
   ) {}
-  generate(name: string): string {
+  generate(name: string, key?: string): string {
+    // すでに登録されているkeyの場合、名前が同名であるならそのkeyが占有している名前であると判断する。
+    if (key !== undefined && this.diaryNameManager.getDiaryName(key) === name) {
+      return name;
+    }
     // 日記名に重複がないか調べる。重複している場合は数字を付加して重複を避ける。
     let newName: string = name;
     let i: number = 1;
-    while (this.diaryNameService.hasDiaryName(newName)) {
+    while (this.diaryNameManager.hasDiaryName(newName)) {
       newName = name + String(i);
       i++;
     }


### PR DESCRIPTION
- launch.json game-diary削除によるディレクトリが変更の適用
- settings.json game-diary削除によるディレクトリが変更の適用
- useEditDIaryName.tsx 名前変更時、自動的にユニークな名前へ変更するように修正
- diaryLoad.test.ts テストの修正
- uniqueDiaryNameGenerator.test.ts テストの修正
- controlDiaryInterface.ts updateDiaryNameの戻り値をユニークな日記名に変更、addDiaryNameを追加
- dIaryNameService.ts ユニークな名前を登録し、その名前を返却するように修正
- editDIarySettings.ts 日記名をユニークに変更し、戻り値にするように修正
- controlDiaryEntryInterface.ts editDIaryNameの戻り値をvoidに修正
- diarySettingsFactory.ts IUniqueDIaryNameGeneratorの利用を停止
- diaryImport.ts IDIaryNameServiceからユニークな名前を取得してSettingsに適用
- diaryLoad.ts IDIaryNameServiceからユニークな名前を取得してSettingsに適用
- diaryRepositoryInterfaces.ts IUniqueDiaryNameGeneratorが既存の日記を更新する際にkeyを引数として受け取るように修正
- uniqueDiaryNameGenerator.ts 既存の日記を更新する際に更新元の日記と更新する名前が一致する場合は名前を変更せずそのまま返すように修正
Fixes #190