### PR TITLE
feat: CurrentDiaryManagerの初期化ロジックを改善  #204

### DIFF
--- a/src/lib/__tests__/model/repository/currentDiaryManager.test.ts
+++ b/src/lib/__tests__/model/repository/currentDiaryManager.test.ts
@@ -1,81 +1,51 @@
 import 'reflect-metadata';
-import { container } from 'tsyringe';
 import CurrentDiaryManager from '@/model/repository/currentDiaryManager';
 import type { IStorageService } from '@/model/utils/storageServiceInterface';
 import DairySettingsConstant from '@/dairySettingsConstant';
 
 describe('CurrentDiaryManager', () => {
-  let storageServiceMock: jest.Mocked<IStorageService>;
-  let isStorageAvailable: jest.Mock;
+  let storage: jest.Mocked<IStorageService>;
+  const diaryKey = 'test-key';
   beforeEach(() => {
-    storageServiceMock = {
-      getItem: jest.fn(),
+    storage = {
+      getItem: jest.fn().mockReturnValue(diaryKey),
       setItem: jest.fn(),
-      removeItem: jest.fn(),
-      length: 0,
-    };
-    isStorageAvailable = jest.fn();
-    container.registerInstance('IStorageService', storageServiceMock);
+    } as unknown as jest.Mocked<IStorageService>;
   });
-
-  afterEach(() => {
-    jest.clearAllMocks();
+  describe('constructor', () => {
+    it('should read currentDiaryKey when can use storage', () => {
+      const manager = new CurrentDiaryManager(storage);
+      expect(manager.getCurrentDiaryKey()).toBe(diaryKey);
+    });
+    it('should set empty string when can not read currentDiaryKey from storage', () => {
+      storage.getItem.mockReturnValue(null);
+      const manager = new CurrentDiaryManager(storage);
+      expect(manager.getCurrentDiaryKey()).toBe('');
+    });
   });
-
-  it('should not set currentDiaryKey if storage is not available', () => {
-    (isStorageAvailable as jest.Mock).mockReturnValue(false);
-
-    const manager = new CurrentDiaryManager(
-      storageServiceMock,
-      isStorageAvailable
-    );
-
-    manager.setCurrentDiaryKey('test-key');
-    expect(storageServiceMock.setItem).not.toHaveBeenCalled();
+  describe('getCurrentDiaryKey', () => {
+    it('should return the currentDiaryKey', () => {
+      const manager = new CurrentDiaryManager(storage);
+      expect(manager.getCurrentDiaryKey()).toBe(diaryKey);
+    });
+    it('should read from storage if reading currentDiaryKey previously failed', () => {
+      storage.getItem.mockReturnValueOnce(null).mockReturnValue(diaryKey);
+      const manager = new CurrentDiaryManager(storage);
+      expect(manager.getCurrentDiaryKey()).toBe(diaryKey);
+      expect(storage.getItem).toHaveBeenCalledWith(
+        DairySettingsConstant.CURRENT_DIARY_KEY
+      );
+    });
   });
-
-  it('should set currentDiaryKey if storage is available and key exists', () => {
-    (isStorageAvailable as jest.Mock).mockReturnValue(true);
-    storageServiceMock.getItem.mockReturnValue('test-key');
-
-    const manager = new CurrentDiaryManager(
-      storageServiceMock,
-      isStorageAvailable
-    );
-
-    expect(manager.getCurrentDiaryKey()).toBe('test-key');
-    expect(storageServiceMock.getItem).toHaveBeenCalledWith(
-      DairySettingsConstant.CURRENT_DIARY_KEY
-    );
-  });
-
-  it('should not set currentDiaryKey if storage is available but key does not exist', () => {
-    (isStorageAvailable as jest.Mock).mockReturnValue(true);
-    storageServiceMock.getItem.mockReturnValue(null);
-
-    const manager = new CurrentDiaryManager(
-      storageServiceMock,
-      isStorageAvailable
-    );
-
-    expect(manager.getCurrentDiaryKey()).toBe('');
-    expect(storageServiceMock.getItem).toHaveBeenCalledWith(
-      DairySettingsConstant.CURRENT_DIARY_KEY
-    );
-  });
-  it('should set currentDiaryKey', () => {
-    (isStorageAvailable as jest.Mock).mockReturnValue(true);
-    const manager = new CurrentDiaryManager(
-      storageServiceMock,
-      isStorageAvailable
-    );
-
-    const key = 'test-key';
-    manager.setCurrentDiaryKey(key);
-    expect(manager.getCurrentDiaryKey()).toBe(key);
-    expect(storageServiceMock.setItem).toHaveBeenCalledWith(
-      DairySettingsConstant.CURRENT_DIARY_KEY,
-      key
-    );
+  describe('setCurrentDiaryKey', () => {
+    it('should set currentDiaryKey', () => {
+      const manager = new CurrentDiaryManager(storage);
+      manager.setCurrentDiaryKey(diaryKey);
+      expect(manager.getCurrentDiaryKey()).toBe(diaryKey);
+      expect(storage.setItem).toHaveBeenCalledWith(
+        DairySettingsConstant.CURRENT_DIARY_KEY,
+        diaryKey
+      );
+    });
   });
 });

--- a/src/lib/model/repository/currentDiaryManager.ts
+++ b/src/lib/model/repository/currentDiaryManager.ts
@@ -6,13 +6,15 @@ import DairySettingsConstant from '@/dairySettingsConstant';
 export default class CurrentDiaryManager implements ICurrentDiaryManager {
   private currentDiaryKey: string = '';
   constructor(@inject('IStorageService') private storage: IStorageService) {
-    const key = this.storage.getItem(DairySettingsConstant.CURRENT_DIARY_KEY);
-    if (key !== null) {
-      this.currentDiaryKey = key;
-      return;
-    }
+    this.currentDiaryKey = this.getCurrentDiaryKey();
   }
   getCurrentDiaryKey(): string {
+    if (this.currentDiaryKey === '') {
+      const key = this.storage.getItem(DairySettingsConstant.CURRENT_DIARY_KEY);
+      if (key !== null) {
+        this.currentDiaryKey = key;
+      }
+    }
     return this.currentDiaryKey;
   }
   setCurrentDiaryKey(key: string): void {


### PR DESCRIPTION
- CurrentDiaryManagerのコンストラクタでのcurrentDiaryKeyの初期化をgetCurrentDiaryKeyメソッドを使用するように変更しました。
- getCurrentDiaryKeyメソッド内で、currentDiaryKeyが空の場合にストレージからキーを取得するロジックを追加しました。