### PR TITLE
feat: diaryDataMigrator.test.tsの修正 Fixes #205

### DIFF
--- a/src/lib/__tests__/__mocks__/mockStorageService.ts
+++ b/src/lib/__tests__/__mocks__/mockStorageService.ts
@@ -6,13 +6,17 @@ import { injectable, singleton } from 'tsyringe';
 export class MockStorageService implements IStorageService {
   private storage = new Map<string, string>();
   constructor() {}
+  isStorageAvailable(): boolean {
+    return true;
+  }
 
   getItem(key: string): string | null {
     const item = this.storage.get(key);
     return item ?? null;
   }
-  setItem(key: string, value: string): void {
+  setItem(key: string, value: string): boolean {
     this.storage.set(key, value);
+    return true;
   }
   removeItem(key: string): void {
     this.storage.delete(key);

--- a/src/lib/__tests__/model/repository/diaryDataMigrator.test.ts
+++ b/src/lib/__tests__/model/repository/diaryDataMigrator.test.ts
@@ -4,70 +4,117 @@ import DairySettingsConstant from '@/dairySettingsConstant';
 import {
   hasField,
   isArrayType,
+  isRecordType,
   isTypeMatch,
 } from '@/model/utils/checkTypeMatch';
 import { InvalidJsonError } from '@/error';
+import { IStorageService } from '@/model/utils/storageServiceInterface';
 
 describe('DiaryDataMigrator class tests', () => {
-  test('is the storage v0 test', () => {
-    const storage = new MockV0StorageService();
-
-    expect(storage.getItem(DairySettingsConstant.CURRENT_GAME_DATA_NAME)).toBe(
-      'testKey0'
-    );
-    const gameDataNameListJson = storage.getItem(
-      DairySettingsConstant.GAME_DATA_NAME_LIST
-    );
-    expect(gameDataNameListJson).not.toBeNull();
-    if (gameDataNameListJson === null) {
-      throw Error;
-    }
-    const gameDataNameJson = JSON.parse(gameDataNameListJson);
-    if (
-      !isTypeMatch(gameDataNameJson, 'Array') ||
-      !isArrayType(gameDataNameJson, 'object') ||
-      !gameDataNameJson.every(
-        (v) =>
-          hasField(v, 'storageKey', 'string') &&
-          hasField(v, 'playGamedataName', 'string')
-      )
-    ) {
-      throw new InvalidJsonError('gameDataNameList is broken');
-    }
-    for (let i = 0; i < 5; i++) {
-      const item = gameDataNameJson[i];
-      expect(item.storageKey).toBe('testKey' + String(i));
-      expect(item.playGamedataName).toBe('testName' + String(i));
-    }
+  let storage: IStorageService;
+  beforeEach(() => {
+    storage = new MockV0StorageService();
   });
-  test('v0 migrator', () => {
-    const storage = new MockV0StorageService();
-    new DiaryDataMigrator(storage).migrate();
-    expect(
-      storage.getItem(DairySettingsConstant.CURRENT_GAME_DATA_NAME)
-    ).toBeNull();
-    expect(storage.getItem(DairySettingsConstant.CURRENT_DIARY_KEY)).toBe(
-      'testKey0'
-    );
-    const keyNamePairJson = storage.getItem(
-      DairySettingsConstant.DIARY_NAME_LIST
-    );
-    if (keyNamePairJson === null) {
-      throw Error;
-    }
-    const keyNamePairObj = JSON.parse(keyNamePairJson);
+  describe('v0 storage service mock', () => {
+    let gameDataNameListJson: string;
+    let gameDataNameEntries: GameDataNameEntry[];
+    type GameDataNameEntry = {
+      storageKey: string;
+      playGamedataName: string;
+    };
+    beforeEach(() => {
+      const json = storage.getItem(DairySettingsConstant.GAME_DATA_NAME_LIST);
+      if (json === null) {
+        throw Error;
+      }
+      gameDataNameListJson = json;
+      const list = JSON.parse(gameDataNameListJson);
+      if (
+        !isTypeMatch(list, 'Array') ||
+        !isArrayType(list, 'object') ||
+        !list.every(
+          (v) =>
+            hasField(v, 'storageKey', 'string') &&
+            hasField(v, 'playGamedataName', 'string')
+        )
+      ) {
+        throw new InvalidJsonError('gameDataNameList is broken');
+      }
+      gameDataNameEntries = list;
+    });
+    it('should store currentGameDataKey in current_game_data_name', () => {
+      expect(
+        storage.getItem(DairySettingsConstant.CURRENT_GAME_DATA_NAME)
+      ).toBe('testKey0');
+    });
+    it('should expose game_data_name_list as an array of objects', () => {
+      expect(isTypeMatch(gameDataNameEntries, 'Array')).toBeTruthy();
+    });
+    it('should validate GameDataNameEntry structure in GAME_DATA_NAME_LIST', () => {
+      // v0では配列の中に{storageKey: string, playGamedataName: string}の形で入っているはず
+      expect(isArrayType(gameDataNameEntries, 'object')).toBeTruthy();
+      expect(
+        gameDataNameEntries.every(
+          (v) =>
+            hasField(v, 'storageKey', 'string') &&
+            hasField(v, 'playGamedataName', 'string')
+        )
+      ).toBeTruthy();
+    });
+    it('should have 5 entries in GAME_DATA_NAME_LIST', () => {
+      expect(gameDataNameEntries.length).toBe(5);
+      for (let i = 0; i < 5; i++) {
+        const item = gameDataNameEntries[i];
+        expect(item.storageKey).toBe('testKey' + String(i));
+        expect(item.playGamedataName).toBe('testName' + String(i));
+      }
+    });
+  });
+  describe('after migration', () => {
+    let diaryNameListJson: string;
+    let gameDataNameRecords: Record<string, string>;
+    beforeEach(() => {
+      new DiaryDataMigrator(storage).migrate();
 
-    if (!isTypeMatch(keyNamePairObj, 'record')) {
-      throw new InvalidJsonError('diaryNameList is broken');
-    }
-    const keyNamePairList = Object.entries(keyNamePairObj);
-    for (let i = 0; i < 5; i++) {
-      const pair = keyNamePairList[i];
-      if (!isArrayType(pair, 'string')) {
+      const s = storage.getItem(DairySettingsConstant.DIARY_NAME_LIST);
+      if (s === null) {
+        throw Error;
+      }
+      diaryNameListJson = s;
+      const obj = JSON.parse(diaryNameListJson);
+      if (!isTypeMatch(obj, 'record') || !isRecordType(obj, 'string')) {
         throw new InvalidJsonError('diaryNameList is broken');
       }
-      expect(pair[0]).toBe('testKey' + String(i));
-      expect(pair[1]).toBe('testName' + String(i));
-    }
+      gameDataNameRecords = obj;
+    });
+    it('should rename current_game_data_name to current_diary_key', () => {
+      expect(
+        storage.getItem(DairySettingsConstant.CURRENT_GAME_DATA_NAME)
+      ).toBeNull();
+      expect(storage.getItem(DairySettingsConstant.CURRENT_DIARY_KEY)).toBe(
+        'testKey0'
+      );
+    });
+    it('should load diary_name_list from storage', () => {
+      expect(diaryNameListJson).not.toBeNull();
+    });
+    it('should expose diary_name_list as a record', () => {
+      expect(isTypeMatch(gameDataNameRecords, 'record')).toBeTruthy();
+    });
+    it('should have valid key/value pairs in diary_name_list', () => {
+      expect(isRecordType(gameDataNameRecords, 'string')).toBeTruthy();
+    });
+    it('should have 5 entries in diary_name_list', () => {
+      const diaryNameEntries = Object.entries(gameDataNameRecords);
+      expect(diaryNameEntries.length).toBe(5);
+      for (let i = 0; i < 5; i++) {
+        const entry = diaryNameEntries[i];
+        if (!isArrayType(entry, 'string')) {
+          throw new InvalidJsonError('diaryNameList is broken');
+        }
+        expect(entry[0]).toBe('testKey' + String(i));
+        expect(entry[1]).toBe('testName' + String(i));
+      }
+    });
   });
 });

--- a/src/lib/model/utils/checkTypeMatch.ts
+++ b/src/lib/model/utils/checkTypeMatch.ts
@@ -65,3 +65,16 @@ export function isArrayType<T extends CheckedType>(
 ): arr is Array<TypeMap[T]> {
   return arr.every((element) => typeof element === type);
 }
+
+/**
+ * レコード内の全要素が指定された型かを確認する。
+ * @param obj 調査対象のレコード
+ * @param type 要素が持つべき型
+ * @returns すべての要素が指定された型の場合は true、それ以外の場合は false
+ */
+export function isRecordType<T extends CheckedType>(
+  obj: Record<string, unknown>,
+  type: T
+): obj is Record<string, TypeMap[T]> {
+  return Object.values(obj).every((element) => typeof element === type);
+}


### PR DESCRIPTION
- diaryDataMigrator.test.ts テストの分割を行いました。
- mockStorageService.ts isStorageAvailableメソッドを追加し、ストレージの可用性を確認できるようにしました。
- mockStorageService.ts setItemメソッドの戻り値をvoidからbooleanに変更し、アイテムの設定成功を示すようにしました。
- checkTypeMatch.ts isRecordType関数を追加し、レコード内の全要素が指定された型であるかを確認できるようにしました。