### PR TITLE
feat: 日記エクスポート機能のテストを改善 Fixes #206

### DIFF
--- a/src/lib/model/repository/diaryService.ts
+++ b/src/lib/model/repository/diaryService.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'tsyringe';
 import type { IDiary } from '@/model/diary/diaryModelInterfaces';
 import type { IDiarySave, IDiaryService } from './diaryRepositoryInterfaces';
-import type { IStorageService } from '../utils/storageServiceInterface';
+import type { IStorageService } from '@/model/utils/storageServiceInterface';
 @injectable()
 export default class DiaryService implements IDiaryService {
   private diaries: Map<string, IDiary> = new Map();
@@ -11,6 +11,8 @@ export default class DiaryService implements IDiaryService {
     @inject('IStorageService') private storage: IStorageService
   ) {}
   getDiary(key: string): IDiary | undefined {
+    // この関数はメモリ上のデータを返すだけでいい
+    // メモリから見つからなければundefinedを返し、ストレージからの読み込みは別の責務に任せる
     return this.diaries.get(key);
   }
   addDiary(diary: IDiary): void {


### PR DESCRIPTION
- diaryExport.test.ts: テストのモック設定を整理し、エクスポート機能のテストを追加
- diaryService.ts: IStorageServiceのインポートパスを修正し、コメントを追加