### PR TITLE
feat: DiaryImportのテストを改善

### DIFF
--- a/src/lib/__tests__/model/repository/diaryImport.test.ts
+++ b/src/lib/__tests__/model/repository/diaryImport.test.ts
@@ -1,35 +1,45 @@
-import 'reflect-metadata';
-import { container } from 'tsyringe';
-import { MockDiary } from '@/__tests__/__mocks__/mockDiary';
 import { IDiaryDecompressor } from '@/model/serialization/serializationInterface';
 import DiaryImport from '@/model/repository/diaryImport';
 import { IDiaryService } from '@/model/repository/diaryRepositoryInterfaces';
+import DiaryNameService from '@/control/controlDiary/diaryNameService';
+import { IDiary, IDiarySettings } from '@/model/diary/diaryModelInterfaces';
 
 describe('DiaryImport', () => {
   let diaryImport: DiaryImport;
   let mockDiaryService: jest.Mocked<IDiaryService>;
   let mockDiaryDecompressor: jest.Mocked<IDiaryDecompressor>;
-  const mockDiary = new MockDiary();
+  let diaryNameService: jest.Mocked<DiaryNameService>;
+  let mockDiary: jest.Mocked<IDiary>;
+  let mockSettings: jest.Mocked<IDiarySettings>;
+  const storageKey = 'testKey';
+  const diaryName = 'My Diary';
+  const uniqueName = 'Unique Diary Name';
   beforeEach(() => {
+    mockSettings = {
+      storageKey: storageKey,
+      getDiaryName: jest.fn().mockReturnValue(diaryName),
+      setDiaryName: jest.fn(),
+    } as unknown as jest.Mocked<IDiarySettings>;
+    mockDiary = {
+      getSettings: jest.fn().mockReturnValue(mockSettings),
+    } as unknown as jest.Mocked<IDiary>;
     mockDiaryService = {
       addDiary: jest.fn(),
-      getDiary: jest.fn(),
-      deleteDiary: jest.fn(),
-    };
-
+    } as unknown as jest.Mocked<IDiaryService>;
     mockDiaryDecompressor = {
       decompressDiary: jest.fn().mockReturnValue(mockDiary),
     };
-
-    container.registerInstance('IDiaryService', mockDiaryService);
-    container.register<IDiaryDecompressor>('IDiaryDecompressor', {
-      useValue: mockDiaryDecompressor,
-    });
-    container.register(DiaryImport, DiaryImport);
-    diaryImport = container.resolve(DiaryImport);
+    diaryNameService = {
+      updateDiaryName: jest.fn().mockReturnValue(uniqueName),
+    } as unknown as jest.Mocked<DiaryNameService>;
+    diaryImport = new DiaryImport(
+      mockDiaryService,
+      mockDiaryDecompressor,
+      diaryNameService
+    );
   });
 
-  it('should import the diary using diary service and decompressDiary function', () => {
+  it('should process diary import by decompressing, saving, and updating names', () => {
     const dairyStr = 'diaryData';
     diaryImport.import(dairyStr);
 
@@ -37,5 +47,11 @@ describe('DiaryImport', () => {
       dairyStr
     );
     expect(mockDiaryService.addDiary).toHaveBeenCalledWith(mockDiary);
+    expect(diaryNameService.updateDiaryName).toHaveBeenCalledWith(
+      storageKey,
+      diaryName
+    );
+    expect(mockSettings.getDiaryName).toHaveBeenCalledWith();
+    expect(mockSettings.setDiaryName).toHaveBeenCalledWith(uniqueName);
   });
 });


### PR DESCRIPTION
- DiaryImportのテストにおいて、依存関係のモックを追加し、テストの可読性と保守性を向上させました。
- DiaryNameServiceとIDiarySettingsのモックを追加し、ダイアリーのインポート処理をより正確にテストできるようにしました。
Fixes #208