### PR TITLE
fix: DairySettingsConstantの名前をDiarySettingsConstantに修正

### DIFF
--- a/src/hooks/useDIaryDelete.tsx
+++ b/src/hooks/useDIaryDelete.tsx
@@ -7,7 +7,7 @@ import useRefreshCurrentDiary from './useRefreshCurrentDiary';
 import { useSelectedDiaryContext } from 'src/components/context/selectedDiaryContext';
 
 const useDiaryDelete = () => {
-  const [dairyDelete, setDiaryDelete] = useState<IDeleteDiary>();
+  const [diaryDelete, setDiaryDelete] = useState<IDeleteDiary>();
   const { useReadHowToUse } = useFetchHowToUse();
   const { refreshCurrentDiary } = useRefreshCurrentDiary();
   const { selectCurrentDiary } = useSelectedDiaryContext();
@@ -17,18 +17,18 @@ const useDiaryDelete = () => {
   }, []);
   const deleteDiary = useCallback(
     async (key: string) => {
-      if (dairyDelete === undefined) {
+      if (diaryDelete === undefined) {
         return;
       }
-      const isDeleted = dairyDelete.delete(key);
+      const isDeleted = diaryDelete.delete(key);
       if (!isDeleted) {
         await useReadHowToUse();
-        dairyDelete.delete(key);
+        diaryDelete.delete(key);
       }
       refreshCurrentDiary();
       selectCurrentDiary();
     },
-    [dairyDelete, useReadHowToUse, refreshCurrentDiary, selectCurrentDiary]
+    [diaryDelete, useReadHowToUse, refreshCurrentDiary, selectCurrentDiary]
   );
   return { deleteDiary };
 };

--- a/src/hooks/useImportDIary.tsx
+++ b/src/hooks/useImportDIary.tsx
@@ -19,16 +19,16 @@ const useImportDiary = () => {
       return;
     }
     const func = () => diaryImporter.importText(text);
-    importDairy(func, 'テキスト');
+    importDiary(func, 'テキスト');
   };
   const importFromFile = (file: File | undefined) => {
     if (file === undefined || diaryImporter === undefined) {
       return;
     }
     const func = () => diaryImporter.importFile(file);
-    importDairy(func, 'ファイル');
+    importDiary(func, 'ファイル');
   };
-  const importDairy = async (func: () => void, type: string) => {
+  const importDiary = async (func: () => void, type: string) => {
     try {
       await func();
       refreshCurrentDiary();

--- a/src/lib/__tests__/__mocks__/mockDayModifier.ts
+++ b/src/lib/__tests__/__mocks__/mockDayModifier.ts
@@ -1,9 +1,9 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import { IDayModifier } from '@/model/diary/diaryModelInterfaces';
 export class MockDayModifier implements IDayModifier {
   unit = Array<string>(4);
-  cycleLength = DairySettingsConstant.DEFAULT_CYCLE_LENGTH;
-  modifier = DairySettingsConstant.DEFAULT_DAY_MODIFIER;
+  cycleLength = DiarySettingsConstant.DEFAULT_CYCLE_LENGTH;
+  modifier = DiarySettingsConstant.DEFAULT_DAY_MODIFIER;
   setModifier(val: string): void {
     this.modifier = val;
   }

--- a/src/lib/__tests__/__mocks__/mockDiarySettings.ts
+++ b/src/lib/__tests__/__mocks__/mockDiarySettings.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import { IDiarySettings } from '@/model/diary/diaryModelInterfaces';
 import { inject, injectable } from 'tsyringe';
 
@@ -19,7 +19,7 @@ export class MockDiarySettings implements IDiarySettings {
   }
   setDiaryName(val: string): void {}
   getDiaryName(): string {
-    return DairySettingsConstant.DEFAULT_DIARY_NAME;
+    return DiarySettingsConstant.DEFAULT_DIARY_NAME;
   }
   updateDayInterval(val: number): void {}
   getDayInterval(): number {
@@ -27,11 +27,11 @@ export class MockDiarySettings implements IDiarySettings {
   }
   setModifier(val: string): void {}
   getModifier(): string {
-    return DairySettingsConstant.DEFAULT_DAY_MODIFIER;
+    return DiarySettingsConstant.DEFAULT_DAY_MODIFIER;
   }
   updateCycleLength(val: number): void {}
   getCycleLength(): number {
-    return DairySettingsConstant.DEFAULT_CYCLE_LENGTH;
+    return DiarySettingsConstant.DEFAULT_CYCLE_LENGTH;
   }
   updateModifierUnit(unit: string, i: number): void {}
 
@@ -42,6 +42,6 @@ export class MockDiarySettings implements IDiarySettings {
     return day + 1;
   }
   getModifierDay(day: number): string {
-    return String(day) + DairySettingsConstant.DEFAULT_DAY_MODIFIER;
+    return String(day) + DiarySettingsConstant.DEFAULT_DAY_MODIFIER;
   }
 }

--- a/src/lib/__tests__/__mocks__/mockEnvironmentStorageService.ts
+++ b/src/lib/__tests__/__mocks__/mockEnvironmentStorageService.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import { MockStorageService } from './mockStorageService';
 import { readFileSync } from 'fs';
 
@@ -9,10 +9,10 @@ export class MockEnvironmentStorageService extends MockStorageService {
     const file = readFileSync(fileName).toString();
     const diaryKey = '726af4c3-30f9-4076-a42e-4645af041097';
     this.setItem(
-      DairySettingsConstant.DIARY_NAME_LIST,
+      DiarySettingsConstant.DIARY_NAME_LIST,
       JSON.stringify([diaryKey, 'test'])
     );
-    this.setItem(DairySettingsConstant.CURRENT_DIARY_KEY, diaryKey);
+    this.setItem(DiarySettingsConstant.CURRENT_DIARY_KEY, diaryKey);
     this.setItem(diaryKey, file);
   }
 }

--- a/src/lib/__tests__/__mocks__/mockV0StorageService.ts
+++ b/src/lib/__tests__/__mocks__/mockV0StorageService.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import { MockStorageService } from './mockStorageService';
 import { injectable, singleton } from 'tsyringe';
 @singleton()
@@ -13,10 +13,10 @@ export class MockV0StorageService extends MockStorageService {
       itemList.push(new Item(itemKey, itemName));
     }
     this.setItem(
-      DairySettingsConstant.GAME_DATA_NAME_LIST,
+      DiarySettingsConstant.GAME_DATA_NAME_LIST,
       JSON.stringify(itemList)
     );
-    this.setItem(DairySettingsConstant.CURRENT_GAME_DATA_NAME, 'testKey0');
+    this.setItem(DiarySettingsConstant.CURRENT_GAME_DATA_NAME, 'testKey0');
   }
 }
 

--- a/src/lib/__tests__/__mocks__/mockV1StorageService.ts
+++ b/src/lib/__tests__/__mocks__/mockV1StorageService.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import { MockStorageService } from './mockStorageService';
 
 export class MockV1StorageService extends MockStorageService {
@@ -11,9 +11,9 @@ export class MockV1StorageService extends MockStorageService {
       itemRecord[itemKey] = itemName;
     }
     this.setItem(
-      DairySettingsConstant.DIARY_NAME_LIST,
+      DiarySettingsConstant.DIARY_NAME_LIST,
       JSON.stringify(itemRecord)
     );
-    this.setItem(DairySettingsConstant.CURRENT_DIARY_KEY, 'testKey0');
+    this.setItem(DiarySettingsConstant.CURRENT_DIARY_KEY, 'testKey0');
   }
 }

--- a/src/lib/__tests__/di.test.ts
+++ b/src/lib/__tests__/di.test.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import DiaryEntry from '@/model/diary/diaryEntry';
 import { IDiaryEntry } from '@/model/diary/diaryModelInterfaces';
 import { container } from 'tsyringe';
@@ -11,7 +11,7 @@ describe('diaryEntry class tests', () => {
     container.register<string>('DEFAULT_TITLE', {
       useValue:
         String(container.resolve<number>('FIRST_DAY')) +
-        DairySettingsConstant.DEFAULT_DAY_MODIFIER,
+        DiarySettingsConstant.DEFAULT_DAY_MODIFIER,
     });
     container.register<undefined>('UNDEFINED', { useFactory: () => undefined });
     container.register<string>('EMPTY_STRING', { useValue: '' });

--- a/src/lib/__tests__/model/diary/dayModifier.test.ts
+++ b/src/lib/__tests__/model/diary/dayModifier.test.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import { IDayModifier, Placeholders } from '@/model/diary/diaryModelInterfaces';
 import { container } from 'tsyringe';
 import '@/container/di_diary';
@@ -19,16 +19,16 @@ describe('DayModifier class tests', () => {
   describe('Dependency Injection tests', () => {
     it('should regist container', () => {
       expect(modifier.getModifier()).toBe(
-        DairySettingsConstant.DEFAULT_DAY_MODIFIER
+        DiarySettingsConstant.DEFAULT_DAY_MODIFIER
       );
       expect(modifier.getCycleLength()).toBe(
-        DairySettingsConstant.DEFAULT_CYCLE_LENGTH
+        DiarySettingsConstant.DEFAULT_CYCLE_LENGTH
       );
       for (let i = 0; i < 4; i++) {
         expect(modifier.getUnit(i)).toBe('');
       }
       expect(modifier.getModifier()).toBe(
-        DairySettingsConstant.DEFAULT_DAY_MODIFIER
+        DiarySettingsConstant.DEFAULT_DAY_MODIFIER
       );
     });
   });
@@ -63,7 +63,7 @@ describe('DayModifier class tests', () => {
       testCycleLength.forEach((val) => {
         modifier.updateCycleLength(val);
         expect(modifier.getCycleLength()).toBe(
-          DairySettingsConstant.DEFAULT_CYCLE_LENGTH
+          DiarySettingsConstant.DEFAULT_CYCLE_LENGTH
         );
       });
     });

--- a/src/lib/__tests__/model/diary/diary.test.ts
+++ b/src/lib/__tests__/model/diary/diary.test.ts
@@ -6,7 +6,7 @@ import {
   UsePreviousDayDiaryEntryFactory,
 } from '@/model/diary/diaryModelInterfaces';
 
-describe('DairySettings class tests', () => {
+describe('DiarySettings class tests', () => {
   let entry: IDiaryEntry;
   let diaryEntries: Map<number, IDiaryEntry>;
   let settings: IDiarySettings;

--- a/src/lib/__tests__/model/diary/diarySettings.test.ts
+++ b/src/lib/__tests__/model/diary/diarySettings.test.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import {
   IDayModifier,
   IDiarySettings,
@@ -7,7 +7,7 @@ import DiarySettings from '@/model/diary/diarySettings';
 import { container } from 'tsyringe';
 import '@/container/di_diary';
 
-describe('DairySettings class tests', () => {
+describe('DiarySettings class tests', () => {
   let modifier: IDayModifier;
   let settings: IDiarySettings;
   beforeEach(() => {
@@ -26,17 +26,17 @@ describe('DairySettings class tests', () => {
     it('should regist container', () => {
       const settings = container.resolve<IDiarySettings>('IDiarySettings');
       expect(settings.getDiaryName()).toBe(
-        DairySettingsConstant.DEFAULT_DIARY_NAME
+        DiarySettingsConstant.DEFAULT_DIARY_NAME
       );
-      expect(settings.version).toBe(DairySettingsConstant.CURRENT_VERSION);
+      expect(settings.version).toBe(DiarySettingsConstant.CURRENT_VERSION);
       expect(settings.getCycleLength()).toBe(
-        DairySettingsConstant.DEFAULT_CYCLE_LENGTH
+        DiarySettingsConstant.DEFAULT_CYCLE_LENGTH
       );
       expect(settings.getDayInterval()).toBe(
-        DairySettingsConstant.DEFAULT_DAY_INTERVAL
+        DiarySettingsConstant.DEFAULT_DAY_INTERVAL
       );
       expect(settings.getModifier()).toBe(
-        DairySettingsConstant.DEFAULT_DAY_MODIFIER
+        DiarySettingsConstant.DEFAULT_DAY_MODIFIER
       );
     });
   });

--- a/src/lib/__tests__/model/repository/currentDiaryManager.test.ts
+++ b/src/lib/__tests__/model/repository/currentDiaryManager.test.ts
@@ -1,7 +1,7 @@
 import 'reflect-metadata';
 import CurrentDiaryManager from '@/model/repository/currentDiaryManager';
 import type { IStorageService } from '@/model/utils/storageServiceInterface';
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 
 describe('CurrentDiaryManager', () => {
   let storage: jest.Mocked<IStorageService>;
@@ -33,7 +33,7 @@ describe('CurrentDiaryManager', () => {
       const manager = new CurrentDiaryManager(storage);
       expect(manager.getCurrentDiaryKey()).toBe(diaryKey);
       expect(storage.getItem).toHaveBeenCalledWith(
-        DairySettingsConstant.CURRENT_DIARY_KEY
+        DiarySettingsConstant.CURRENT_DIARY_KEY
       );
     });
   });
@@ -43,7 +43,7 @@ describe('CurrentDiaryManager', () => {
       manager.setCurrentDiaryKey(diaryKey);
       expect(manager.getCurrentDiaryKey()).toBe(diaryKey);
       expect(storage.setItem).toHaveBeenCalledWith(
-        DairySettingsConstant.CURRENT_DIARY_KEY,
+        DiarySettingsConstant.CURRENT_DIARY_KEY,
         diaryKey
       );
     });

--- a/src/lib/__tests__/model/repository/diaryDataMigrator.test.ts
+++ b/src/lib/__tests__/model/repository/diaryDataMigrator.test.ts
@@ -1,6 +1,6 @@
 import DiaryDataMigrator from '@/model/repository/diaryDataMigrator';
 import { MockV0StorageService } from '../../__mocks__/mockV0StorageService';
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import {
   hasField,
   isArrayType,
@@ -23,7 +23,7 @@ describe('DiaryDataMigrator class tests', () => {
       playGamedataName: string;
     };
     beforeEach(() => {
-      const json = storage.getItem(DairySettingsConstant.GAME_DATA_NAME_LIST);
+      const json = storage.getItem(DiarySettingsConstant.GAME_DATA_NAME_LIST);
       if (json === null) {
         throw Error;
       }
@@ -44,7 +44,7 @@ describe('DiaryDataMigrator class tests', () => {
     });
     it('should store currentGameDataKey in current_game_data_name', () => {
       expect(
-        storage.getItem(DairySettingsConstant.CURRENT_GAME_DATA_NAME)
+        storage.getItem(DiarySettingsConstant.CURRENT_GAME_DATA_NAME)
       ).toBe('testKey0');
     });
     it('should expose game_data_name_list as an array of objects', () => {
@@ -76,7 +76,7 @@ describe('DiaryDataMigrator class tests', () => {
     beforeEach(() => {
       new DiaryDataMigrator(storage).migrate();
 
-      const s = storage.getItem(DairySettingsConstant.DIARY_NAME_LIST);
+      const s = storage.getItem(DiarySettingsConstant.DIARY_NAME_LIST);
       if (s === null) {
         throw Error;
       }
@@ -89,9 +89,9 @@ describe('DiaryDataMigrator class tests', () => {
     });
     it('should rename current_game_data_name to current_diary_key', () => {
       expect(
-        storage.getItem(DairySettingsConstant.CURRENT_GAME_DATA_NAME)
+        storage.getItem(DiarySettingsConstant.CURRENT_GAME_DATA_NAME)
       ).toBeNull();
-      expect(storage.getItem(DairySettingsConstant.CURRENT_DIARY_KEY)).toBe(
+      expect(storage.getItem(DiarySettingsConstant.CURRENT_DIARY_KEY)).toBe(
         'testKey0'
       );
     });

--- a/src/lib/__tests__/model/repository/diaryImport.test.ts
+++ b/src/lib/__tests__/model/repository/diaryImport.test.ts
@@ -40,11 +40,11 @@ describe('DiaryImport', () => {
   });
 
   it('should process diary import by decompressing, saving, and updating names', () => {
-    const dairyStr = 'diaryData';
-    diaryImport.import(dairyStr);
+    const diaryStr = 'diaryData';
+    diaryImport.import(diaryStr);
 
     expect(mockDiaryDecompressor.decompressDiary).toHaveBeenCalledWith(
-      dairyStr
+      diaryStr
     );
     expect(mockDiaryService.addDiary).toHaveBeenCalledWith(mockDiary);
     expect(diaryNameService.updateDiaryName).toHaveBeenCalledWith(

--- a/src/lib/__tests__/model/repository/diaryLoad.test.ts
+++ b/src/lib/__tests__/model/repository/diaryLoad.test.ts
@@ -13,7 +13,7 @@ describe('DiaryLoad', () => {
   let mockDiaryDecompressor: jest.Mocked<IDiaryDecompressor>;
   let mockDiaryNameService: jest.Mocked<IDiaryNameService>;
   let mockDiary: jest.Mocked<IDiary>;
-  const dairyKey = 'diaryKey';
+  const diaryKey = 'diaryKey';
   beforeEach(() => {
     mockDiaryService = {
       getDiary: jest.fn(),
@@ -32,7 +32,7 @@ describe('DiaryLoad', () => {
       getSettings: jest.fn().mockReturnValue({
         getDiaryName: jest.fn().mockReturnValue('Original Diary Name'),
         setDiaryName: jest.fn(),
-        storageKey: dairyKey,
+        storageKey: diaryKey,
       } as unknown as jest.Mocked<IDiarySettings>),
     } as unknown as jest.Mocked<IDiary>;
   });
@@ -45,9 +45,9 @@ describe('DiaryLoad', () => {
       mockDiaryDecompressor,
       mockDiaryNameService
     );
-    const loadResult = diaryLoad.load(dairyKey);
+    const loadResult = diaryLoad.load(diaryKey);
     expect(loadResult).toBe(mockDiary);
-    expect(mockDiaryService.getDiary).toHaveBeenCalledWith(dairyKey);
+    expect(mockDiaryService.getDiary).toHaveBeenCalledWith(diaryKey);
   });
   it('should return a KeyNotFoundError if the data does not exist in either IDiaryService or IStorageService', () => {
     // DiaryServiceにもストレージにもデータがない場合、エラーをスローする
@@ -59,8 +59,8 @@ describe('DiaryLoad', () => {
       mockDiaryDecompressor,
       mockDiaryNameService
     );
-    expect(() => diaryLoad.load(dairyKey)).toThrow(
-      new KeyNotFoundError(`Key "${dairyKey}" not found`)
+    expect(() => diaryLoad.load(diaryKey)).toThrow(
+      new KeyNotFoundError(`Key "${diaryKey}" not found`)
     );
   });
   it('should load and return diary from IStorageService when not found in IDiaryService', () => {
@@ -75,15 +75,15 @@ describe('DiaryLoad', () => {
       mockDiaryDecompressor,
       mockDiaryNameService
     );
-    const loadResult = diaryLoad.load(dairyKey);
+    const loadResult = diaryLoad.load(diaryKey);
 
     expect(loadResult).toBe(mockDiary);
-    expect(mockStorageService.getItem).toHaveBeenCalledWith(dairyKey);
+    expect(mockStorageService.getItem).toHaveBeenCalledWith(diaryKey);
     expect(mockDiaryDecompressor.decompressDiary).toHaveBeenCalledWith(
       'compressedDiaryData'
     );
     expect(mockDiaryNameService.updateDiaryName).toHaveBeenCalledWith(
-      dairyKey,
+      diaryKey,
       mockDiary.getSettings().getDiaryName()
     );
     expect(mockDiary.getSettings().setDiaryName).toHaveBeenCalledWith(

--- a/src/lib/__tests__/model/repository/diaryNameManager.test.ts
+++ b/src/lib/__tests__/model/repository/diaryNameManager.test.ts
@@ -2,7 +2,7 @@ import DiaryNameManager from '@/model/repository/diaryNameManager';
 import { IDiaryNameManager } from '@/model/repository/diaryRepositoryInterfaces';
 import { IStorageService } from '@/model/utils/storageServiceInterface';
 import { InvalidJsonError } from '@/error';
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 
 describe('DiaryNameManager class tests', () => {
   let diaryNameManager: IDiaryNameManager;
@@ -60,7 +60,7 @@ describe('DiaryNameManager class tests', () => {
         expect.arrayContaining(Object.entries(diaryRecord))
       );
       expect(mockStorage.setItem).toHaveBeenCalledWith(
-        DairySettingsConstant.DIARY_NAME_LIST,
+        DiarySettingsConstant.DIARY_NAME_LIST,
         JSON.stringify(diaryRecord)
       );
     });
@@ -97,7 +97,7 @@ describe('DiaryNameManager class tests', () => {
         expect.arrayContaining(Object.entries(diaryRecord))
       );
       expect(mockStorage.setItem).toHaveBeenCalledWith(
-        DairySettingsConstant.DIARY_NAME_LIST,
+        DiarySettingsConstant.DIARY_NAME_LIST,
         JSON.stringify(diaryRecord)
       );
     });

--- a/src/lib/container/di_diary.ts
+++ b/src/lib/container/di_diary.ts
@@ -29,7 +29,7 @@ import {
 } from '@/model/repository/diaryRepositoryInterfaces';
 import DiaryEntry from '@/model/diary/diaryEntry';
 import Diary from '@/model/diary/diary';
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import DayModifier from '@/model/diary/dayModifier';
 import DiarySettings from '@/model/diary/diarySettings';
 import StorageService from '@/model/utils/storageService';
@@ -120,13 +120,13 @@ container.register<number>('FIRST_DAY', {
 container.register<string>('DEFAULT_TITLE', {
   useValue:
     String(container.resolve<number>('FIRST_DAY')) +
-    DairySettingsConstant.DEFAULT_DAY_MODIFIER,
+    DiarySettingsConstant.DEFAULT_DAY_MODIFIER,
 });
 container.register<string>('HOW_TO_USE_TEXT_URL', {
-  useValue: DairySettingsConstant.HOW_TO_USE_TEXT_URL,
+  useValue: DiarySettingsConstant.HOW_TO_USE_TEXT_URL,
 });
 container.register<string>('HOW_TO_USE_KEY', {
-  useValue: DairySettingsConstant.HOW_TO_USE_KEY,
+  useValue: DiarySettingsConstant.HOW_TO_USE_KEY,
 });
 container.register<string>('EMPTY_STRING', { useValue: '' });
 container.register<undefined>('UNDEFINED', { useFactory: () => undefined });
@@ -150,16 +150,16 @@ container.register<IDiarySettings>('IDiarySettings', {
   useClass: DiarySettings,
 });
 container.register<string>('DIARY_NAME', {
-  useValue: DairySettingsConstant.DEFAULT_DIARY_NAME,
+  useValue: DiarySettingsConstant.DEFAULT_DIARY_NAME,
 });
 container.register<number>('DAY_INTERVAL', {
-  useValue: DairySettingsConstant.DEFAULT_DAY_INTERVAL,
+  useValue: DiarySettingsConstant.DEFAULT_DAY_INTERVAL,
 });
 container.register<string>('STORAGE_KEY', {
   useFactory: () => crypto.randomUUID(),
 });
 container.register<number>('VERSION', {
-  useValue: DairySettingsConstant.CURRENT_VERSION,
+  useValue: DiarySettingsConstant.CURRENT_VERSION,
 });
 container.register<IDiarySettingsFactory>('IDiarySettingsFactory', {
   useClass: DiarySettingsFactory,
@@ -169,7 +169,7 @@ container.register<DefaultSettingsFactory>('DefaultSettingsFactory', {
 });
 
 container.register<Placeholders>('Placeholders', {
-  useValue: DairySettingsConstant.PLACEHOLDERS,
+  useValue: DiarySettingsConstant.PLACEHOLDERS,
 });
 
 container.register<IDayModifier>('IDayModifier', {
@@ -177,10 +177,10 @@ container.register<IDayModifier>('IDayModifier', {
 });
 
 container.register<string>('DAY_MODIFIER', {
-  useValue: DairySettingsConstant.DEFAULT_DAY_MODIFIER,
+  useValue: DiarySettingsConstant.DEFAULT_DAY_MODIFIER,
 });
 container.register<number>('CYCLE_LENGTH', {
-  useValue: DairySettingsConstant.DEFAULT_CYCLE_LENGTH,
+  useValue: DiarySettingsConstant.DEFAULT_CYCLE_LENGTH,
 });
 
 container.register<UseExistingDataDayModifierFactory>(

--- a/src/lib/diarySettingsConstant.ts
+++ b/src/lib/diarySettingsConstant.ts
@@ -1,7 +1,7 @@
 /**
  * 定数を管理するためのクラス。
  */
-export default class DairySettingsConstant {
+export default class DiarySettingsConstant {
   static readonly CURRENT_VERSION: number = 1;
   static readonly DEFAULT_DIARY_NAME: string = '新しい日記';
   static readonly DEFAULT_DAY_INTERVAL: number = 1;
@@ -19,7 +19,7 @@ export default class DairySettingsConstant {
   static readonly DAY_PLACEHOLDER: string = '$D';
   static readonly TOTAL_DAYS_PLACEHOLDER: string = '$N';
   static readonly DEFAULT_DAY_MODIFIER: string =
-    DairySettingsConstant.TOTAL_DAYS_PLACEHOLDER + '日目';
+    DiarySettingsConstant.TOTAL_DAYS_PLACEHOLDER + '日目';
 
   /** v0で使用していたカレントの日記のストレージキーを保存するためのキー。実際にはストレージキーが入るためv1で修正 */
   static readonly CURRENT_GAME_DATA_NAME: string = 'currentGameDataName';

--- a/src/lib/model/diary/diaryEntry.ts
+++ b/src/lib/model/diary/diaryEntry.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import { IDiaryEntry, IDiarySettings } from './diaryModelInterfaces';
 import { inject, injectable } from 'tsyringe';
 

--- a/src/lib/model/repository/currentDiaryManager.ts
+++ b/src/lib/model/repository/currentDiaryManager.ts
@@ -1,7 +1,7 @@
 import { inject, injectable } from 'tsyringe';
 import type { IStorageService } from '../utils/storageServiceInterface';
 import { ICurrentDiaryManager } from './diaryRepositoryInterfaces';
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 @injectable()
 export default class CurrentDiaryManager implements ICurrentDiaryManager {
   private currentDiaryKey: string = '';
@@ -10,7 +10,7 @@ export default class CurrentDiaryManager implements ICurrentDiaryManager {
   }
   getCurrentDiaryKey(): string {
     if (this.currentDiaryKey === '') {
-      const key = this.storage.getItem(DairySettingsConstant.CURRENT_DIARY_KEY);
+      const key = this.storage.getItem(DiarySettingsConstant.CURRENT_DIARY_KEY);
       if (key !== null) {
         this.currentDiaryKey = key;
       }
@@ -19,6 +19,6 @@ export default class CurrentDiaryManager implements ICurrentDiaryManager {
   }
   setCurrentDiaryKey(key: string): void {
     this.currentDiaryKey = key;
-    this.storage.setItem(DairySettingsConstant.CURRENT_DIARY_KEY, key);
+    this.storage.setItem(DiarySettingsConstant.CURRENT_DIARY_KEY, key);
   }
 }

--- a/src/lib/model/repository/diaryDataMigrator.ts
+++ b/src/lib/model/repository/diaryDataMigrator.ts
@@ -1,6 +1,6 @@
 import { inject, injectable } from 'tsyringe';
 import { IDiaryDataMigrator } from './diaryRepositoryInterfaces';
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import type { IStorageService } from '@/model/utils/storageServiceInterface';
 import { InvalidJsonError } from '@/error';
 import {
@@ -17,7 +17,7 @@ export default class DiaryDataMigrator implements IDiaryDataMigrator {
   migrate(): void {
     // current_game_data_nameが存在するならv0
     const v0CurrentDiaryKey = this.storage.getItem(
-      DairySettingsConstant.CURRENT_GAME_DATA_NAME
+      DiarySettingsConstant.CURRENT_GAME_DATA_NAME
     );
     if (v0CurrentDiaryKey !== null) {
       this.migrateV0toV1();
@@ -31,19 +31,19 @@ export default class DiaryDataMigrator implements IDiaryDataMigrator {
   migrateV0toV1(): void {
     // CURRENT_GAME_DATA_NAMEをCURRENT_DIARY_KEYに名前変更
     const v0CurrentDiaryKey = this.storage.getItem(
-      DairySettingsConstant.CURRENT_GAME_DATA_NAME
+      DiarySettingsConstant.CURRENT_GAME_DATA_NAME
     );
     if (v0CurrentDiaryKey !== null) {
-      this.storage.removeItem(DairySettingsConstant.CURRENT_GAME_DATA_NAME);
+      this.storage.removeItem(DiarySettingsConstant.CURRENT_GAME_DATA_NAME);
       this.storage.setItem(
-        DairySettingsConstant.CURRENT_DIARY_KEY,
+        DiarySettingsConstant.CURRENT_DIARY_KEY,
         v0CurrentDiaryKey
       );
     }
 
     // まず、itemListを初期化し、ストレージからゲームデータ名のリストを取得する。
     const diaryNameList = this.storage.getItem(
-      DairySettingsConstant.GAME_DATA_NAME_LIST
+      DiarySettingsConstant.GAME_DATA_NAME_LIST
     );
     if (diaryNameList === null) {
       return;
@@ -67,10 +67,10 @@ export default class DiaryDataMigrator implements IDiaryDataMigrator {
       keyNamePairObj[v.storageKey] = v.playGamedataName;
     });
     // gameDataListを削除
-    this.storage.removeItem(DairySettingsConstant.GAME_DATA_NAME_LIST);
+    this.storage.removeItem(DiarySettingsConstant.GAME_DATA_NAME_LIST);
     // diaryNameListへと保存
     this.storage.setItem(
-      DairySettingsConstant.DIARY_NAME_LIST,
+      DiarySettingsConstant.DIARY_NAME_LIST,
       JSON.stringify(keyNamePairObj)
     );
   }

--- a/src/lib/model/repository/diaryNameManager.ts
+++ b/src/lib/model/repository/diaryNameManager.ts
@@ -1,4 +1,4 @@
-import DairySettingsConstant from '@/dairySettingsConstant';
+import DiarySettingsConstant from '@/diarySettingsConstant';
 import { isTypeMatch } from '@/model/utils/checkTypeMatch';
 import type { IStorageService } from '@/model/utils/storageServiceInterface';
 import { inject, injectable } from 'tsyringe';
@@ -11,7 +11,7 @@ export default class DiaryNameManager implements IDiaryNameManager {
 
   constructor(@inject('IStorageService') private storage: IStorageService) {
     // まず、itemListを初期化し、ストレージからゲームデータ名のリストを取得する。
-    const recordStr = storage.getItem(DairySettingsConstant.DIARY_NAME_LIST);
+    const recordStr = storage.getItem(DiarySettingsConstant.DIARY_NAME_LIST);
     if (recordStr === null) {
       // nullならデータが存在しない
       return;
@@ -50,7 +50,7 @@ export default class DiaryNameManager implements IDiaryNameManager {
     //ストレージキーと名前を保存してストレージに登録する
     this.diaryNames[key] = name;
     const result = this.storage.setItem(
-      DairySettingsConstant.DIARY_NAME_LIST,
+      DiarySettingsConstant.DIARY_NAME_LIST,
       JSON.stringify(this.diaryNames)
     );
     if (!result) {
@@ -72,7 +72,7 @@ export default class DiaryNameManager implements IDiaryNameManager {
     this.diaryNameSet.delete(removeName);
     delete this.diaryNames[key];
     this.storage.setItem(
-      DairySettingsConstant.DIARY_NAME_LIST,
+      DiarySettingsConstant.DIARY_NAME_LIST,
       JSON.stringify(this.diaryNames)
     );
   }


### PR DESCRIPTION
Fixes #229

- useDIaryDelete.tsx: dairyDeleteの変数名を修正
- useImportDIary.tsx: importDairyの関数名を修正
- mockDayModifier.ts: DairySettingsConstantのインポート名を修正
- mockDiarySettings.ts: DairySettingsConstantのインポート名を修正
- mockEnvironmentStorageService.ts: DairySettingsConstantのインポート名を修正
- mockV0StorageService.ts: DairySettingsConstantのインポート名を修正
- mockV1StorageService.ts: DairySettingsConstantのインポート名を修正
- di.test.ts: DairySettingsConstantのインポート名を修正
- dayModifier.test.ts: DairySettingsConstantのインポート名を修正
- diary.test.ts: DairySettingsのテスト名を修正
- diarySettings.test.ts: DairySettingsConstantのインポート名を修正
- currentDiaryManager.test.ts: DairySettingsConstantのインポート名を修正
- diaryDataMigrator.test.ts: DairySettingsConstantのインポート名を修正
- diaryImport.test.ts: dairyStrの変数名を修正
- diaryLoad.test.ts: dairyKeyの変数名を修正
- diaryNameManager.test.ts: DairySettingsConstantのインポート名を修正
- di_diary.ts: DairySettingsConstantのインポート名を修正
- diarySettingsConstant.ts: 新しい定数クラスを追加
- diaryEntry.ts: DairySettingsConstantのインポート名を修正
- currentDiaryManager.ts: DairySettingsConstantのインポート名を修正
- diaryDataMigrator.ts: DairySettingsConstantのインポート名を修正
- diaryNameManager.ts: DairySettingsConstantのインポート名を修正