### PR TITLE
fix: DiarySaveテストのリファクタリング Fix #211

### DIFF
--- a/src/lib/__tests__/model/repository/diarySave.test.ts
+++ b/src/lib/__tests__/model/repository/diarySave.test.ts
@@ -1,60 +1,43 @@
 import 'reflect-metadata';
 import DiarySave from '@/model/repository/diarySave';
-import { IDiary } from '@/model/diary/diaryModelInterfaces';
-import {
-  IsStorageAvailableFunc,
-  IStorageService,
-} from '@/model/utils/storageServiceInterface';
-import { container } from 'tsyringe';
-import { MockDiary } from '@/__tests__/__mocks__/mockDiary';
+import { IDiary, IDiarySettings } from '@/model/diary/diaryModelInterfaces';
+import { IStorageService } from '@/model/utils/storageServiceInterface';
 import { CompressDiary } from '@/model/serialization/serializationInterface';
-import { MockDiarySettings } from '@/__tests__/__mocks__/mockDiarySettings';
-import { UnusedStorageError } from '@/error';
 
 describe('DiarySave', () => {
   let diarySave: DiarySave;
   let mockStorageService: jest.Mocked<IStorageService>;
   let mockCompressDiary: jest.Mocked<CompressDiary>;
-  let mockIsStorageAvailableFunc: jest.Mocked<IsStorageAvailableFunc>;
-  const mockSettings = new MockDiarySettings();
+  let mockSettings: jest.Mocked<IDiarySettings>;
+  let mockDiary: jest.Mocked<IDiary>;
   beforeEach(() => {
     mockStorageService = {
       setItem: jest.fn(),
-      getItem: jest.fn(),
-      removeItem: jest.fn(),
-      length: 0,
-    };
-
+    } as unknown as jest.Mocked<IStorageService>;
+    mockSettings = {
+      storageKey: 'diaryStorageKey',
+    } as unknown as jest.Mocked<IDiarySettings>;
+    mockDiary = {
+      getSettings: jest.fn().mockReturnValue(mockSettings),
+    } as unknown as jest.Mocked<IDiary>;
     mockCompressDiary = jest.fn().mockReturnValue('compressedDiaryData');
-    container.register('IDiary', { useFactory: () => new MockDiary() });
-    container.register(DiarySave, DiarySave);
   });
 
-  it('should save the diary using storage service, isStorageAvailableFunc and compressDiaryFunc', () => {
-    const mockDiary: IDiary = container.resolve('IDiary');
-    mockIsStorageAvailableFunc = jest.fn().mockReturnValue(true);
-    diarySave = new DiarySave(
-      mockStorageService,
-      mockCompressDiary,
-      mockIsStorageAvailableFunc
-    );
-    diarySave.save(mockDiary);
+  it('should compress diary and save it using storage key', () => {
+    mockStorageService.setItem.mockReturnValue(true);
+    diarySave = new DiarySave(mockStorageService, mockCompressDiary);
+    const result = diarySave.save(mockDiary);
+    expect(result).toBeTruthy();
     expect(mockCompressDiary).toHaveBeenCalledWith(mockDiary);
     expect(mockStorageService.setItem).toHaveBeenCalledWith(
       mockSettings.storageKey,
       'compressedDiaryData'
     );
   });
-  it('should can not use teh storage', () => {
-    const mockDiary: IDiary = container.resolve('IDiary');
-    mockIsStorageAvailableFunc = jest.fn().mockReturnValue(false);
-    diarySave = new DiarySave(
-      mockStorageService,
-      mockCompressDiary,
-      mockIsStorageAvailableFunc
-    );
-    expect(() => diarySave.save(mockDiary)).toThrow(
-      new UnusedStorageError('can not you use the storage')
-    );
+  it('should return false when setItem fails', () => {
+    mockStorageService.setItem.mockReturnValue(false);
+    diarySave = new DiarySave(mockStorageService, mockCompressDiary);
+    const result = diarySave.save(mockDiary);
+    expect(result).toBeFalsy();
   });
 });


### PR DESCRIPTION
- 不要なインポートを削除し、テストの可読性を向上させました。
- MockDiarySettingsとUnusedStorageErrorの使用を削除しました。
- テストケースを整理し、ストレージサービスの保存処理を確認するテストを明確にしました。