### PR TITLE
fix: ユニーク日記名生成器のエラーハンドリングを追加 Fixes #213

### DIFF
--- a/src/lib/__tests__/model/repository/uniqueDiaryNameGenerator.test.ts
+++ b/src/lib/__tests__/model/repository/uniqueDiaryNameGenerator.test.ts
@@ -50,4 +50,10 @@ describe('UniqueDiaryNameGenerator', () => {
     expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(1, 'newDiary');
     expect(nameManager.hasDiaryName).toHaveBeenNthCalledWith(2, 'newDiary1');
   });
+  it('should throw an error if unable to generate a unique name after many attempts', () => {
+    nameManager.hasDiaryName.mockReturnValue(true);
+    expect(() => {
+      nameGenerator.generate('diary');
+    }).toThrow('Unable to generate a unique diary name.');
+  });
 });

--- a/src/lib/model/repository/uniqueDiaryNameGenerator.ts
+++ b/src/lib/model/repository/uniqueDiaryNameGenerator.ts
@@ -21,6 +21,9 @@ export default class UniqueDiaryNameGenerator
     while (this.diaryNameManager.hasDiaryName(newName)) {
       newName = name + String(i);
       i++;
+      if (i > 10000) {
+        throw new Error('Unable to generate a unique diary name.');
+      }
     }
     return newName;
   }


### PR DESCRIPTION
- uniqueDiaryNameGenerator.ts: 生成に失敗した場合にエラーをスローするロジックを追加しました。
- uniqueDiaryNameGenerator.test.ts: 生成失敗時のエラーハンドリングをテストするケースを追加しました。